### PR TITLE
Rename project name ('nestrr-flock') to 'flock-backend'

### DIFF
--- a/.run/Spring_Debug/Spring_ Debug with Doppler.run.xml
+++ b/.run/Spring_Debug/Spring_ Debug with Doppler.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Spring: Debug with Doppler" type="Remote">
-    <module name="nestrr-flock" />
+    <module name="flock-backend" />
     <option name="USE_SOCKET_TRANSPORT" value="true" />
     <option name="SERVER_MODE" value="false" />
     <option name="SHMEM_ADDRESS" />

--- a/.run/Spring_Test/Spring_ Test with Doppler.run.xml
+++ b/.run/Spring_Test/Spring_ Test with Doppler.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Spring: Test with Doppler" type="JUnit" factoryName="JUnit">
-    <module name="nestrr-flock" />
+    <module name="flock-backend" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="com.nestrr.apps.flock.profile.*" />

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.nestrr.apps.flock</groupId>
-    <artifactId>nestrr-flock</artifactId>
+    <artifactId>flock-backend</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <name>nestrr-flock</name>
+    <name>flock-backend</name>
     <description>Flock by Nestrr</description>
     <url/>
     <licenses>
@@ -133,7 +133,7 @@
             <plugin>
                 <configuration>
                     <image>
-                        <name>nestrr-flock</name>
+                        <name>flock-backend</name>
                     </image>
                 </configuration>
                 <groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-spring.application.name: nestrr-flock
+spring.application.name: flock-backend
 oidc:
   config:
     url: https://login.microsoftonline.com/${MICROSOFT_ENTRA_TENANT_ID}/v2.0/.well-known/openid-configuration


### PR DESCRIPTION
This PR simply renames the original project to `flock-backend`, to reflect the repository's name.