### PR TITLE
Publish Docker images on push to develop and main branches

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,41 @@
+name: Publish Docker images
+on:
+  push:
+    branches:
+      - main, develop
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  build:
+    name: Build and publish image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'zulu'
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Publish image
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_ACTOR: ${{github.actor}}
+          BRANCH_NAME: ${{ github.ref_name }}
+        run: |
+          case "$BRANCH_NAME" in 
+            "develop") TAG=canary;;
+            "main") TAG=latest;;
+            *) echo "Unsupported branch name: $BRANCH_NAME." && exit 1;;
+          esac
+          mvn -DskipTests -B -Ddocker.publishRegistry.username=$GH_ACTOR -Ddocker.publishRegistry.password=$GH_TOKEN -Ddocker.publishRegistry.url=ghcr.io -Dspring-boot.build-image.publish=true -Dspring-boot.build-image.imageName=ghcr.io/nestrr/flock-backend:$TAG package

--- a/pom.xml
+++ b/pom.xml
@@ -134,10 +134,20 @@
         <plugins>
             <plugin>
                 <configuration>
-                    <image>
-                        <name>flock-backend</name>
-                    </image>
+                    <docker>
+                        <publishRegistry>
+                            <url>https://ghcr.io/nestrr/</url>
+                            <publish>true</publish>
+                        </publishRegistry>
+                    </docker>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-image-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -133,14 +133,6 @@
     <build>
         <plugins>
             <plugin>
-                <configuration>
-                    <docker>
-                        <publishRegistry>
-                            <url>https://ghcr.io/nestrr/</url>
-                            <publish>true</publish>
-                        </publishRegistry>
-                    </docker>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -148,6 +140,16 @@
                         </goals>
                     </execution>
                 </executions>
+
+                <configuration>
+                    <docker>
+                        <publishRegistry>
+                            <url>${docker.publishRegistry.url}</url>
+                            <username>${docker.publishRegistry.username}</username>
+                            <password>${docker.publishRegistry.password}</password>
+                        </publishRegistry>
+                    </docker>
+                </configuration>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
See FLOC-25. After this PR, Docker images will be published via GitHub Packages to facilitate containerization and make the backend more portable. 