### PR TITLE
Fix branch specifications in publish.yaml

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,8 @@ name: Publish Docker images
 on:
   push:
     branches:
-      - main, develop
+      - main
+      - develop
 
 permissions:
   packages: write


### PR DESCRIPTION
Currently, the publish.yaml workflow does not run. This is because the branches are incorrectly specified. This PR creates a quick fix.