### PR TITLE
Refactor PersonService to only manage Persons

### DIFF
--- a/src/main/java/com/nestrr/apps/flock/profile/dto/CampusChoicesDto.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/dto/CampusChoicesDto.java
@@ -1,5 +1,6 @@
 package com.nestrr.apps.flock.profile.dto;
 
+import com.nestrr.apps.flock.campus.dto.CampusDto;
 import java.util.List;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/nestrr/apps/flock/profile/entity/Degree.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/entity/Degree.java
@@ -1,0 +1,19 @@
+package com.nestrr.apps.flock.profile.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Degree {
+  @Id private String id;
+
+  @Version private Integer version;
+
+  private String programCode;
+
+  private String degreeTypeCode;
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/entity/Person.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/entity/Person.java
@@ -1,10 +1,8 @@
 package com.nestrr.apps.flock.profile.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
-
 import java.time.LocalDateTime;
-import java.util.UUID;
+import lombok.*;
 
 @Entity
 @Data
@@ -19,6 +17,6 @@ public class Person {
   private String image;
   private String bio;
   private String standingId;
-  private String majorId;
+  private String degreeId;
   private LocalDateTime lastLogin;
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/service/CampusChoiceService.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/CampusChoiceService.java
@@ -1,10 +1,10 @@
 package com.nestrr.apps.flock.profile.service;
 
-import com.nestrr.apps.flock.profile.dto.CampusDto;
+import com.nestrr.apps.flock.campus.dto.CampusDto;
 import java.util.List;
 
 public interface CampusChoiceService {
   List<CampusDto> getCampusChoices(String personId);
 
-  void updateCampusChoices(String personId, List<String> newChoices);
+  void updateCampusChoices(String personId, List<String> newChoices, List<String> deletedChoices);
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/service/PersonService.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/PersonService.java
@@ -1,14 +1,14 @@
 package com.nestrr.apps.flock.profile.service;
 
 import com.nestrr.apps.flock.profile.entity.Person;
-
 import java.sql.SQLDataException;
-import java.util.List;
 
 public interface PersonService {
-  Person getOrCreatePerson(String id, String email, String name, String image, List<String> roles);
+  void createPersonIfNeeded(String id, String email, String name, String image);
 
-  void updatePerson(String id, String name, String profilePicture, String bio);
+  Person getPerson(String id) throws SQLDataException;
+
+  void updatePerson(Person person);
 
   void deletePerson(String id);
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/service/PersonServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/PersonServiceImpl.java
@@ -1,63 +1,40 @@
 package com.nestrr.apps.flock.profile.service;
 
-import com.nestrr.apps.flock.profile.entity.Person;
-import com.nestrr.apps.flock.profile.entity.Role;
-import com.nestrr.apps.flock.profile.entity.RoleAssignment;
-import com.nestrr.apps.flock.profile.repository.PersonRepository;
-import com.nestrr.apps.flock.profile.repository.RoleAssignmentRepository;
-import com.nestrr.apps.flock.profile.repository.RoleRepository;
-import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Optional;
-
 import static com.nestrr.apps.flock.util.BeanCopyUtils.copyNonNullProperties;
+
+import com.nestrr.apps.flock.profile.entity.Person;
+import com.nestrr.apps.flock.profile.repository.PersonRepository;
+import java.sql.SQLDataException;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
 
 @Service
 public class PersonServiceImpl implements PersonService {
 
   private final PersonRepository personRepository;
-  private final RoleAssignmentRepository roleAssignmentRepository;
-  private final RoleRepository roleRepository;
 
-  public PersonServiceImpl(
-      PersonRepository personRepository,
-      RoleAssignmentRepository roleAssignmentRepository,
-      RoleRepository roleRepository) {
+  public PersonServiceImpl(PersonRepository personRepository) {
     this.personRepository = personRepository;
-    this.roleAssignmentRepository = roleAssignmentRepository;
-    this.roleRepository = roleRepository;
   }
 
   @Override
-  public Person getOrCreatePerson(
-      String id, String email, String name, String image, List<String> roles) {
+  public void createPersonIfNeeded(String id, String email, String name, String image) {
     Optional<Person> existingPerson = personRepository.findById(id);
-    return existingPerson.orElseGet(
+    existingPerson.orElseGet(
         () ->
-            createPerson(
-                Person.builder().id(id).email(email).name(name).image(image).build(), roles));
-  }
-
-  public Person createPerson(Person toCreate, List<String> roles) {
-    Person person = personRepository.save(toCreate);
-    for (String role : roles) {
-      assignRole(person.getId(), role);
-    }
-    return person;
-  }
-
-  public void assignRole(String personId, String roleName) {
-    Role role = roleRepository.findByName(roleName).orElseThrow();
-    roleAssignmentRepository.save(
-        RoleAssignment.builder().personId(personId).roleId(role.getId()).build());
+            personRepository.save(
+                Person.builder().id(id).email(email).name(name).image(image).build()));
   }
 
   @Override
-  public void updatePerson(String id, String name, String profilePicture, String bio) {
-    Person person = personRepository.findById(id).orElseThrow();
-    copyNonNullProperties(
-        Person.builder().name(name).bio(bio).image(profilePicture).build(), person);
+  public Person getPerson(String id) throws SQLDataException {
+    return personRepository.findById(id).orElseThrow(() -> new SQLDataException("No such person!"));
+  }
+
+  @Override
+  public void updatePerson(Person personToUpdate) {
+    Person person = personRepository.findById(personToUpdate.getId()).orElseThrow();
+    copyNonNullProperties(personToUpdate, person);
 
     personRepository.save(person);
   }


### PR DESCRIPTION
Currently the PersonService manages setting and updating role assignments. While that doesn't seem too problematic, it is a violation of Single Responsibility principle. PersonService should only manage Person-related information and logic. This PR ensures that that separation takes place. It also checks in some changes that were accidentally left out of previous PRs.