### PR TITLE
Refactor ProfileFacadeService and expand ProfileController

### DIFF
--- a/src/main/java/com/nestrr/apps/flock/profile/controller/ProfileController.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/controller/ProfileController.java
@@ -18,9 +18,15 @@ public class ProfileController {
   }
 
   @PostMapping("/me")
-  public ResponseEntity<ProfileDto> getOrCreateProfile(
+  public ResponseEntity<String> storeNewProfile(
       Authentication auth, @RequestBody @Valid OidcProfileRequest oidcProfileRequest) {
-    ProfileDto profileDto = profileFacadeService.getOrCreateProfile(auth, oidcProfileRequest);
-    return ResponseEntity.ok(profileDto);
+    profileFacadeService.storeNewProfile(auth, oidcProfileRequest);
+    return ResponseEntity.noContent().build();
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<ProfileDto> getProfile(Authentication auth) {
+    ProfileDto profileDto = profileFacadeService.getProfile(auth);
+    return profileDto != null ? ResponseEntity.ok(profileDto) : ResponseEntity.notFound().build();
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/dto/CampusChoicesUpdateRequest.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/dto/CampusChoicesUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.nestrr.apps.flock.profile.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class CampusChoicesUpdateRequest {
+  private List<String> added;
+  private List<String> deleted;
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/dto/ProfileDto.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/dto/ProfileDto.java
@@ -1,6 +1,9 @@
 package com.nestrr.apps.flock.profile.dto;
 
+import com.nestrr.apps.flock.campus.dto.CampusDto;
+import com.nestrr.apps.flock.standing.dto.StandingDto;
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
 
@@ -12,9 +15,10 @@ public class ProfileDto {
   private String email;
   private String image;
   private String bio;
-  private String standing;
-  private String major;
+  private StandingDto standing;
+  private DegreeDto degree;
   private Boolean firstLogin;
   private List<String> roles;
   private List<CampusDto> campusChoices;
+  private Map<String, List<TimeslotDto>> preferredTimes;
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/dto/ProfileUpdateRequest.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/dto/ProfileUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.nestrr.apps.flock.profile.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class ProfileUpdateRequest {
+  private String bio;
+  private String image;
+  private String standingId;
+  private String programCode;
+  private String degreeTypeCode;
+  private CampusChoicesUpdateRequest campusChoices;
+  private TimeslotUpdateRequest preferredTimes;
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/dto/TimeslotDto.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/dto/TimeslotDto.java
@@ -1,0 +1,15 @@
+package com.nestrr.apps.flock.profile.dto;
+
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class TimeslotDto {
+  private String id;
+  private LocalTime from;
+  private LocalTime to;
+  private Integer reliability;
+  private Integer flexibility;
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/dto/TimeslotUpdateRequest.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/dto/TimeslotUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.nestrr.apps.flock.profile.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+public class TimeslotUpdateRequest {
+  private List<List<TimeslotDto>> added;
+  private List<List<TimeslotDto>> deleted;
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/entity/Timeslot.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/entity/Timeslot.java
@@ -19,7 +19,7 @@ public class Timeslot {
 
   private LocalTime startTime;
   private LocalTime endTime;
-  private String reliability;
+  private Integer reliability;
 
-  private String flexibility;
+  private Integer flexibility;
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/mapper/ProfileMapper.java
@@ -1,9 +1,14 @@
 package com.nestrr.apps.flock.profile.mapper;
 
-import com.nestrr.apps.flock.profile.dto.CampusDto;
-import com.nestrr.apps.flock.profile.dto.ProfileDto;
+import com.nestrr.apps.flock.campus.dto.CampusDto;
+import com.nestrr.apps.flock.profile.dto.*;
 import com.nestrr.apps.flock.profile.entity.Person;
+import com.nestrr.apps.flock.profile.mapper.constants.ProfileMapperConstants;
+import com.nestrr.apps.flock.standing.dto.StandingDto;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 import org.springframework.stereotype.Component;
@@ -30,24 +35,33 @@ public interface ProfileMapper {
    * Maps Person entity to ProfileDto.
    *
    * @param person - The Person entity
-   * @param major - The major name
+   * @param degree - The degree details
    * @param standing - The year name (e.g. freshman)
    * @return ProfileDto complete ProfileDto
    */
-  default ProfileDto personToProfileDto(
+  default ProfileDto toProfileDto(
       Person person,
       List<String> roles,
-      String standing,
-      String major,
+      StandingDto standing,
+      DegreeDto degree,
+      List<TimeslotDto> preferredTimesList,
       List<CampusDto> campusChoices) {
+    Map<String, List<TimeslotDto>> preferredTimesMap = new HashMap<>();
+    for (int i = 0; i < preferredTimesList.size(); i++) {
+      TimeslotDto timeslot = preferredTimesList.get(i);
+      preferredTimesMap
+          .computeIfAbsent(ProfileMapperConstants.DAYS[i], k -> new ArrayList<>())
+          .add(timeslot);
+    }
     return ProfileDto.builder()
         .name(person.getName())
         .email(person.getEmail())
         .image(person.getImage())
         .bio(person.getBio())
         .standing(standing)
-        .major(major)
+        .degree(degree)
         .roles(roles)
+        .preferredTimes(preferredTimesMap)
         .campusChoices(campusChoices)
         .firstLogin(person.getLastLogin() == null)
         .build();

--- a/src/main/java/com/nestrr/apps/flock/profile/mapper/TimeslotMapper.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/mapper/TimeslotMapper.java
@@ -1,0 +1,29 @@
+package com.nestrr.apps.flock.profile.mapper;
+
+import com.nestrr.apps.flock.profile.dto.TimeslotDto;
+import com.nestrr.apps.flock.profile.entity.Timeslot;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.springframework.stereotype.Component;
+
+@Component
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE, componentModel = "spring")
+public interface TimeslotMapper {
+  @Mapping(source = "startTime", target = "from")
+  @Mapping(source = "endTime", target = "to")
+  TimeslotDto toTimeslotDto(Timeslot timeslot);
+
+  @Mapping(source = "from", target = "startTime")
+  @Mapping(source = "to", target = "endTime")
+  default Timeslot fromTimeslotDto(TimeslotDto timeslotDto, String personId, Integer day) {
+    return Timeslot.builder()
+        .personId(personId)
+        .day(day)
+        .startTime(timeslotDto.getFrom())
+        .endTime(timeslotDto.getTo())
+        .reliability(timeslotDto.getReliability())
+        .flexibility(timeslotDto.getFlexibility())
+        .build();
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/mapper/constants/ProfileMapperConstants.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/mapper/constants/ProfileMapperConstants.java
@@ -1,0 +1,7 @@
+package com.nestrr.apps.flock.profile.mapper.constants;
+
+public class ProfileMapperConstants {
+  public static final String[] DAYS = {
+    "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+  };
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/repository/CampusChoiceRankRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/repository/CampusChoiceRankRepository.java
@@ -1,6 +1,6 @@
 package com.nestrr.apps.flock.profile.repository;
 
-import com.nestrr.apps.flock.profile.entity.Campus;
+import com.nestrr.apps.flock.campus.entity.Campus;
 import com.nestrr.apps.flock.profile.entity.CampusChoiceRank;
 import com.nestrr.apps.flock.profile.entity.id.CampusChoiceRankId;
 import java.util.List;

--- a/src/main/java/com/nestrr/apps/flock/profile/repository/RoleAssignmentRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/repository/RoleAssignmentRepository.java
@@ -14,5 +14,5 @@ public interface RoleAssignmentRepository
       nativeQuery = true,
       value =
           "SELECT r.name FROM role_assignment ra JOIN role r ON ra.role_id=r.id WHERE ra.person_id=?")
-  Optional<List<String>> listRolesByPersonId(String subId);
+  Optional<List<String>> listRolesByPersonId(String personId);
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/repository/TimeslotRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/repository/TimeslotRepository.java
@@ -3,17 +3,19 @@ package com.nestrr.apps.flock.profile.repository;
 import com.nestrr.apps.flock.profile.entity.Timeslot;
 import com.nestrr.apps.flock.profile.entity.id.TimeslotId;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.ListPagingAndSortingRepository;
 
 public interface TimeslotRepository
     extends ListPagingAndSortingRepository<Timeslot, TimeslotId>,
-        CrudRepository<Timeslot, TimeslotId> {
+        ListCrudRepository<Timeslot, TimeslotId> {
   Optional<Timeslot> findByDay(Integer day);
 
-  Optional<Timeslot> findByPersonId(String personId);
+  @Query(nativeQuery = true, value = "SELECT * FROM timeslot WHERE person_id=?1")
+  Optional<List<Timeslot>> findByPersonId(String personId);
 
   /** Any time after this start time <b>exclusive</b>. */
   @Query(nativeQuery = true, value = "SELECT * FROM timeslot WHERE start_time>=?1")

--- a/src/main/java/com/nestrr/apps/flock/profile/service/ProfileFacadeService.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/ProfileFacadeService.java
@@ -2,9 +2,14 @@ package com.nestrr.apps.flock.profile.service;
 
 import com.nestrr.apps.flock.profile.dto.OidcProfileRequest;
 import com.nestrr.apps.flock.profile.dto.ProfileDto;
+import com.nestrr.apps.flock.profile.dto.ProfileUpdateRequest;
 import org.springframework.security.core.Authentication;
 
 public interface ProfileFacadeService {
 
-  ProfileDto getOrCreateProfile(Authentication a, OidcProfileRequest oidcProfileRequest);
+  void storeNewProfile(Authentication a, OidcProfileRequest oidcProfileRequest);
+
+  void updateProfile(Authentication a, ProfileUpdateRequest profileUpdateRequest);
+
+  ProfileDto getProfile(Authentication a);
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/service/ProfileFacadeServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/ProfileFacadeServiceImpl.java
@@ -3,10 +3,14 @@ package com.nestrr.apps.flock.profile.service;
 import static com.nestrr.apps.flock.util.AuthenticationUtil.getJwtId;
 import static com.nestrr.apps.flock.util.AuthenticationUtil.getRoles;
 
-import com.nestrr.apps.flock.profile.dto.OidcProfileRequest;
-import com.nestrr.apps.flock.profile.dto.ProfileDto;
+import com.nestrr.apps.flock.profile.dto.*;
+import com.nestrr.apps.flock.profile.entity.Degree;
 import com.nestrr.apps.flock.profile.entity.Person;
 import com.nestrr.apps.flock.profile.mapper.ProfileMapper;
+import com.nestrr.apps.flock.standing.dto.StandingDto;
+import com.nestrr.apps.flock.standing.service.StandingService;
+import io.micrometer.common.util.StringUtils;
+import java.sql.SQLDataException;
 import java.util.List;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -16,38 +20,99 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProfileFacadeServiceImpl implements ProfileFacadeService {
 
   private final PersonService personService;
-
+  private final TimeslotService timeslotService;
+  private final RoleAssignmentService roleAssignmentService;
   private final CampusChoiceService campusChoiceService;
+  private final StandingService standingService;
+  private final DegreeFacadeService degreeFacadeService;
   private final ProfileMapper profileMapper;
 
   public ProfileFacadeServiceImpl(
       PersonService personService,
       CampusChoiceService campusChoiceService,
+      RoleAssignmentService roleAssignmentService,
+      TimeslotService timeslotService,
+      StandingService standingService,
+      DegreeFacadeService degreeFacadeService,
       ProfileMapper profileMapper) {
     this.personService = personService;
+    this.roleAssignmentService = roleAssignmentService;
     this.campusChoiceService = campusChoiceService;
+    this.timeslotService = timeslotService;
+    this.standingService = standingService;
+    this.degreeFacadeService = degreeFacadeService;
     this.profileMapper = profileMapper;
   }
 
   @Override
   @Transactional
-  public ProfileDto getOrCreateProfile(Authentication a, OidcProfileRequest oidcProfileRequest) {
+  public void storeNewProfile(Authentication a, OidcProfileRequest oidcProfileRequest) {
     String personId = getJwtId(a);
     List<String> roles = getRoles(a);
-    Person person =
-        personService.getOrCreatePerson(
-            personId,
-            oidcProfileRequest.getEmail(),
-            oidcProfileRequest.getName(),
-            oidcProfileRequest.getImage(),
-            roles);
+    personService.createPersonIfNeeded(
+        personId,
+        oidcProfileRequest.getEmail(),
+        oidcProfileRequest.getName(),
+        oidcProfileRequest.getImage());
+    roleAssignmentService.storeRoleAssignments(personId, roles);
+  }
 
-    return profileMapper
-        .personToBaseProfileDtoBuilder(person)
-        .roles(roles)
-        .campusChoices(campusChoiceService.getCampusChoices(personId))
-        .major("")
-        .standing("")
-        .build();
+  @Override
+  public void updateProfile(Authentication a, ProfileUpdateRequest profileUpdateRequest) {
+    String personId = getJwtId(a);
+    String degreeId = null;
+    if (!StringUtils.isBlank(profileUpdateRequest.getDegreeTypeCode())
+        && !StringUtils.isBlank(profileUpdateRequest.getProgramCode())) {
+      Degree degree =
+          degreeFacadeService.getDegreeByTypeAndProgramCodes(
+              profileUpdateRequest.getDegreeTypeCode(), profileUpdateRequest.getProgramCode());
+      degreeId = degree.getId();
+    }
+    Person person =
+        Person.builder()
+            .id(personId)
+            .image(profileUpdateRequest.getImage())
+            .bio(profileUpdateRequest.getBio())
+            .degreeId(degreeId)
+            .standingId(profileUpdateRequest.getStandingId())
+            .build();
+    personService.updatePerson(person);
+    if (profileUpdateRequest.getCampusChoices() != null)
+      campusChoiceService.updateCampusChoices(
+          personId,
+          profileUpdateRequest.getCampusChoices().getAdded(),
+          profileUpdateRequest.getCampusChoices().getDeleted());
+    if (profileUpdateRequest.getPreferredTimes() != null)
+      timeslotService.updateTimeslots(
+          personId,
+          profileUpdateRequest.getPreferredTimes().getAdded(),
+          profileUpdateRequest.getPreferredTimes().getDeleted());
+  }
+
+  @Override
+  public ProfileDto getProfile(Authentication a) {
+    String personId = getJwtId(a);
+    List<String> roles = getRoles(a);
+    try {
+      Person person = personService.getPerson(personId);
+      StandingDto standing =
+          person.getStandingId() == null
+              ? null
+              : standingService.getStandingById(person.getStandingId());
+      DegreeDto degree =
+          person.getDegreeId() == null
+              ? null
+              : degreeFacadeService.getDegreeById(person.getDegreeId());
+      List<TimeslotDto> preferredTimes = timeslotService.getTimeslots(personId);
+      return profileMapper.toProfileDto(
+          person,
+          roles,
+          standing,
+          degree,
+          preferredTimes,
+          campusChoiceService.getCampusChoices(personId));
+    } catch (SQLDataException e) {
+      return null;
+    }
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/service/RoleAssignmentService.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/RoleAssignmentService.java
@@ -1,0 +1,11 @@
+package com.nestrr.apps.flock.profile.service;
+
+import java.util.List;
+
+public interface RoleAssignmentService {
+  List<String> getRoles(String personId);
+
+  void storeRoleAssignments(String personId, List<String> roles);
+
+  //  void updateRoleAssignments(String personId, List<String> roles);
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/service/RoleAssignmentServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/RoleAssignmentServiceImpl.java
@@ -1,0 +1,36 @@
+package com.nestrr.apps.flock.profile.service;
+
+import com.nestrr.apps.flock.profile.entity.Role;
+import com.nestrr.apps.flock.profile.entity.RoleAssignment;
+import com.nestrr.apps.flock.profile.repository.RoleAssignmentRepository;
+import com.nestrr.apps.flock.profile.repository.RoleRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RoleAssignmentServiceImpl implements RoleAssignmentService {
+  private final RoleAssignmentRepository roleAssignmentRepository;
+  private final RoleRepository roleRepository;
+
+  public RoleAssignmentServiceImpl(
+      RoleAssignmentRepository roleAssignmentRepository, RoleRepository roleRepository) {
+    this.roleAssignmentRepository = roleAssignmentRepository;
+    this.roleRepository = roleRepository;
+  }
+
+  @Override
+  public List<String> getRoles(String personId) {
+    Optional<List<String>> roleAssignments = roleAssignmentRepository.listRolesByPersonId(personId);
+    return roleAssignments.orElseGet(List::of);
+  }
+
+  @Override
+  public void storeRoleAssignments(String personId, List<String> roles) {
+    for (String roleName : roles) {
+      Role role = roleRepository.findByName(roleName).orElseThrow();
+      roleAssignmentRepository.save(
+          RoleAssignment.builder().personId(personId).roleId(role.getId()).build());
+    }
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/service/TimeslotService.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/TimeslotService.java
@@ -1,0 +1,12 @@
+package com.nestrr.apps.flock.profile.service;
+
+import com.nestrr.apps.flock.profile.dto.TimeslotDto;
+import java.util.List;
+
+public interface TimeslotService {
+
+  List<TimeslotDto> getTimeslots(String personId);
+
+  void updateTimeslots(
+      String personId, List<List<TimeslotDto>> added, List<List<TimeslotDto>> deleted);
+}

--- a/src/main/java/com/nestrr/apps/flock/profile/service/TimeslotServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/TimeslotServiceImpl.java
@@ -1,0 +1,50 @@
+package com.nestrr.apps.flock.profile.service;
+
+import com.nestrr.apps.flock.profile.dto.TimeslotDto;
+import com.nestrr.apps.flock.profile.entity.Timeslot;
+import com.nestrr.apps.flock.profile.entity.id.TimeslotId;
+import com.nestrr.apps.flock.profile.mapper.TimeslotMapper;
+import com.nestrr.apps.flock.profile.repository.TimeslotRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TimeslotServiceImpl implements TimeslotService {
+  private final TimeslotRepository timeslotRepository;
+  private final TimeslotMapper timeslotMapper;
+
+  public TimeslotServiceImpl(
+      TimeslotRepository timeslotRepository,
+      TimeslotMapper timeslotMapper) {
+    this.timeslotRepository = timeslotRepository;
+    this.timeslotMapper = timeslotMapper;
+  }
+
+  @Override
+  public List<TimeslotDto> getTimeslots(String personId) {
+    Optional<List<Timeslot>> timeslots = this.timeslotRepository.findByPersonId(personId);
+    return timeslots
+        .map(timeslotList -> timeslotList.stream().map(timeslotMapper::toTimeslotDto).toList())
+        .orElseGet(List::of);
+  }
+
+  @Override
+  public void updateTimeslots(
+      String personId, List<List<TimeslotDto>> added, List<List<TimeslotDto>> deleted) {
+    for (int day = 0; day < added.size(); day++) {
+      List<TimeslotDto> timeslotsInDay = added.get(day);
+      int currentDay = day;
+      timeslotsInDay.stream()
+          .map(t -> timeslotMapper.fromTimeslotDto(t, personId, currentDay))
+          .forEach(timeslotRepository::save);
+    }
+    for (int day = 0; day < deleted.size(); day++) {
+      List<TimeslotDto> timeslotsInDay = added.get(day);
+      int currentDay = day;
+      deleted.stream()
+          .map(t -> new TimeslotId(personId, currentDay))
+          .forEach(timeslotRepository::deleteById);
+    }
+  }
+}


### PR DESCRIPTION
This PR refactors ProfileFacadeService so it uses the refactors introduced in the preceding PRs. It also expands ProfileController so users can store or update profile details, and adds the supporting backend logic to allow that to happen.
Finally, this PR checks in a change that was accidentally left out of #18, which updates the CampusChoiceRankRepository's Campus entity import.