### PR TITLE
Move to Neon

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,13 @@
-spring.application.name: flock-backend
 oidc:
   config:
     url: https://login.microsoftonline.com/${MICROSOFT_ENTRA_TENANT_ID}/v2.0/.well-known/openid-configuration
   jwk:
     url: https://login.microsoftonline.com/${MICROSOFT_ENTRA_TENANT_ID}/discovery/v2.0/keys
 spring:
+  application:
+    name: flock-backend
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}?user=${DB_USER}&password=${DB_PASSWORD}&sslmode=require
+    url: jdbc:postgresql://${DB_HOST}/${DB_NAME}?user=${DB_USER}&password=${DB_PASSWORD}&sslmode=require
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
Supabase's efforts to upgrade to pg v17 [have stalled](https://github.com/orgs/supabase/discussions/19427#discussioncomment-11427482). Accordingly, this PR switches the Flock backend over to Neon. Since Liquibase applies the database changes, nothing needs to budge except for the URL, which lacks a port number when using Neon.
