### PR TITLE
FLOC-56: Fix bug regarding firstLogin property in /profile/me response

### DIFF
--- a/src/main/java/com/nestrr/apps/flock/profile/dto/ProfileDto.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/dto/ProfileDto.java
@@ -8,13 +8,13 @@ import lombok.Data;
 @Builder
 @Data
 public class ProfileDto {
+  private Boolean newAccount;
   private String name;
   private String email;
   private String image;
   private String bio;
   private StandingDto standing;
   private DegreeDto degree;
-  private Boolean firstLogin;
   private List<String> roles;
   private List<CampusDto> campusChoices;
   private Map<String, List<TimeslotDto>> timeslots;

--- a/src/main/java/com/nestrr/apps/flock/profile/entity/Profile.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/entity/Profile.java
@@ -8,6 +8,7 @@ import com.nestrr.apps.flock.profile.entity.converter.CampusDtoAttributeConverte
 import com.nestrr.apps.flock.profile.entity.converter.DegreeDtoAttributeConverter;
 import com.nestrr.apps.flock.profile.entity.converter.TimeslotDtoAttributeConverter;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.*;
 import org.hibernate.annotations.Immutable;
@@ -33,6 +34,9 @@ public class Profile {
 
   @Column(insertable = false, updatable = false)
   private String image;
+
+  @Column(insertable = false, updatable = false)
+  private LocalDateTime lastLogin;
 
   @Column(insertable = false, updatable = false)
   private String bio;

--- a/src/main/java/com/nestrr/apps/flock/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/mapper/ProfileMapper.java
@@ -23,37 +23,26 @@ public interface ProfileMapper {
   default ProfileDto toProfileDto(Profile profile) {
 
     List<TimeslotDto> timeslots = profile.getTimeslots();
+    ProfileDto.ProfileDtoBuilder base =
+        ProfileDto.builder()
+            .name(profile.getName())
+            .email(profile.getEmail())
+            .image(profile.getImage())
+            .bio(profile.getBio())
+            .standing(profile.getStanding())
+            .degree(profile.getDegree())
+            .roles(profile.getRoles())
+            .campusChoices(profile.getCampusChoices())
+            .newAccount(profile.getLastLogin() == null);
     if (timeslots != null) {
       Map<String, List<TimeslotDto>> timeslotsMap = new HashMap<>();
-      for (int i = 0; i < timeslots.size(); i++) {
-        TimeslotDto timeslot = timeslots.get(i);
+      for (TimeslotDto timeslot : timeslots) {
         timeslotsMap
             .computeIfAbsent(ProfileMapperConstants.DAYS[timeslot.day()], k -> new ArrayList<>())
             .add(timeslot);
       }
-      return ProfileDto.builder()
-          .name(profile.getName())
-          .email(profile.getEmail())
-          .image(profile.getImage())
-          .bio(profile.getBio())
-          .standing(profile.getStanding())
-          .degree(profile.getDegree())
-          .roles(profile.getRoles())
-          .timeslots(timeslotsMap)
-          .campusChoices(profile.getCampusChoices())
-          //        .firstLogin(profile.getLastLogin() == null)
-          .build();
+      return base.timeslots(timeslotsMap).build();
     }
-    return ProfileDto.builder()
-        .name(profile.getName())
-        .email(profile.getEmail())
-        .image(profile.getImage())
-        .bio(profile.getBio())
-        .standing(profile.getStanding())
-        .degree(profile.getDegree())
-        .roles(profile.getRoles())
-        .campusChoices(profile.getCampusChoices())
-        //        .firstLogin(profile.getLastLogin() == null)
-        .build();
+    return base.build();
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/service/PersonServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/service/PersonServiceImpl.java
@@ -5,7 +5,7 @@ import static com.nestrr.apps.flock.util.BeanCopyUtils.copyNonNullProperties;
 import com.nestrr.apps.flock.profile.entity.Person;
 import com.nestrr.apps.flock.profile.repository.PersonRepository;
 import java.sql.SQLDataException;
-import java.util.Optional;
+import java.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -19,11 +19,13 @@ public class PersonServiceImpl implements PersonService {
 
   @Override
   public void createPersonIfNeeded(String id, String email, String name, String image) {
-    Optional<Person> existingPerson = personRepository.findById(id);
-    existingPerson.orElseGet(
-        () ->
-            personRepository.save(
-                Person.builder().id(id).email(email).name(name).image(image).build()));
+    Person person = personRepository.findById(id).orElse(null);
+    if (person != null) {
+      person.setLastLogin(LocalDateTime.now());
+    } else {
+      person = Person.builder().id(id).email(email).name(name).image(image).build();
+    }
+    personRepository.save(person);
   }
 
   @Override

--- a/src/main/resources/db/changelog/changelog-1.0/changelog-1.0.2.yaml
+++ b/src/main/resources/db/changelog/changelog-1.0/changelog-1.0.2.yaml
@@ -71,6 +71,7 @@ databaseChangeLog:
                       p.email, 
                       p.bio, 
                       p.image, 
+                      p.last_login,
                       d.degree,
                       r.roles, 
                       s.standing,

--- a/src/test/java/com/nestrr/apps/flock/profile/ProfileControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/profile/ProfileControllerTest.java
@@ -58,7 +58,7 @@ class ProfileControllerTest extends AbstractIntegrationTest {
             .image(oidcProfileRequest.getImage())
             .bio(null)
             .timeslots(null)
-            .firstLogin(null)
+            .newAccount(true)
             .roles(List.of("student"))
             .campusChoices(null)
             .build();


### PR DESCRIPTION
The GET /profile/me endpoint should return a `firstLogin` property that indicates whether this is the user's first login. It returns null at the moment, which is inaccurate (as it should be a true/false value). 
This PR makes the following changes:
- Include last_login column in the `profile` view.
- Update Profile entity accordingly.
- Rename firstLogin property of ProfileDto to newAccount for clarity, and update ProfileMapper accordingly.
