### PR TITLE
Include user ID in ProfileDto

### DIFF
--- a/src/main/java/com/nestrr/apps/flock/profile/dto/ProfileDto.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/dto/ProfileDto.java
@@ -8,6 +8,7 @@ import lombok.Data;
 @Builder
 @Data
 public class ProfileDto {
+  private String id;
   private Boolean newAccount;
   private String name;
   private String email;

--- a/src/main/java/com/nestrr/apps/flock/profile/mapper/ProfileMapper.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/mapper/ProfileMapper.java
@@ -25,6 +25,7 @@ public interface ProfileMapper {
     List<TimeslotDto> timeslots = profile.getTimeslots();
     ProfileDto.ProfileDtoBuilder base =
         ProfileDto.builder()
+            .id(profile.getId())
             .name(profile.getName())
             .email(profile.getEmail())
             .image(profile.getImage())


### PR DESCRIPTION
This PR allows user IDs to be returned through the ProfileDto so that the frontend can track a user's ID when displaying or manipulating the profile.
