### PR TITLE
Allow users to create groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,14 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/src/main/java/com/nestrr/apps/flock/config/EmailConfig.java
+++ b/src/main/java/com/nestrr/apps/flock/config/EmailConfig.java
@@ -1,0 +1,30 @@
+package com.nestrr.apps.flock.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.spring6.ISpringTemplateEngine;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+import org.thymeleaf.templateresolver.ITemplateResolver;
+
+@Configuration
+public class EmailConfig {
+  @Bean
+  public ISpringTemplateEngine emailTemplateEngine() {
+    final SpringTemplateEngine result = new SpringTemplateEngine();
+    // Html email resolver
+    result.addTemplateResolver(this.htmlTemplateResolver());
+    return result;
+  }
+
+  @Bean
+  public ITemplateResolver htmlTemplateResolver() {
+    ClassLoaderTemplateResolver result = new ClassLoaderTemplateResolver();
+    result.setPrefix("email-templates/");
+    result.setSuffix(".html");
+    result.setTemplateMode(TemplateMode.HTML);
+    result.setCharacterEncoding("UTF-8");
+    return result;
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/constants/GroupInviteConstants.java
+++ b/src/main/java/com/nestrr/apps/flock/group/constants/GroupInviteConstants.java
@@ -1,0 +1,5 @@
+package com.nestrr.apps.flock.group.constants;
+
+public final class GroupInviteConstants {
+  public static final Long INVITE_WAIT_PERIOD_DAYS = 7L;
+}

--- a/src/main/java/com/nestrr/apps/flock/group/constants/GroupInviteStatuses.java
+++ b/src/main/java/com/nestrr/apps/flock/group/constants/GroupInviteStatuses.java
@@ -1,0 +1,17 @@
+package com.nestrr.apps.flock.group.constants;
+
+public enum GroupInviteStatuses {
+  ACCEPTED("accepted"),
+  REJECTED("rejected"),
+  RESPONSE_PENDING("response_pending"),
+  EXPIRED("expired");
+  public final String value;
+
+  GroupInviteStatuses(String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return this.value;
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/constants/GroupStatuses.java
+++ b/src/main/java/com/nestrr/apps/flock/group/constants/GroupStatuses.java
@@ -1,0 +1,15 @@
+package com.nestrr.apps.flock.group.constants;
+
+public enum GroupStatuses {
+  ACTIVE("active"),
+  PENDING("pending");
+  public final String value;
+
+  GroupStatuses(String value) {
+    this.value = value;
+  }
+
+  public String value() {
+    return this.value;
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/controller/GroupController.java
+++ b/src/main/java/com/nestrr/apps/flock/group/controller/GroupController.java
@@ -1,0 +1,33 @@
+package com.nestrr.apps.flock.group.controller;
+
+import com.nestrr.apps.flock.group.dto.GroupDto;
+import com.nestrr.apps.flock.group.dto.NewGroupRequest;
+import com.nestrr.apps.flock.group.service.GroupFacadeService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/group")
+public class GroupController {
+
+  private final GroupFacadeService groupFacadeService;
+
+  public GroupController(GroupFacadeService groupFacadeService) {
+    this.groupFacadeService = groupFacadeService;
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<List<GroupDto>> getSelfGroups(Authentication auth) {
+    return ResponseEntity.ok(List.of());
+  }
+
+  @PostMapping
+  public ResponseEntity<String> saveGroup(
+      Authentication auth, @Valid @RequestBody NewGroupRequest newGroupRequest) {
+    groupFacadeService.createGroup(auth, newGroupRequest);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/controller/GroupInviteController.java
+++ b/src/main/java/com/nestrr/apps/flock/group/controller/GroupInviteController.java
@@ -1,0 +1,3 @@
+package com.nestrr.apps.flock.group.controller;
+
+public class GroupInviteController {}

--- a/src/main/java/com/nestrr/apps/flock/group/controller/GroupMembershipController.java
+++ b/src/main/java/com/nestrr/apps/flock/group/controller/GroupMembershipController.java
@@ -1,0 +1,3 @@
+package com.nestrr.apps.flock.group.controller;
+
+public class GroupMembershipController {}

--- a/src/main/java/com/nestrr/apps/flock/group/dto/GroupDto.java
+++ b/src/main/java/com/nestrr/apps/flock/group/dto/GroupDto.java
@@ -1,0 +1,9 @@
+package com.nestrr.apps.flock.group.dto;
+
+public record GroupDto(
+    String id,
+    String name,
+    String description,
+    String image,
+    String adminId,
+    GroupStatusDto status) {}

--- a/src/main/java/com/nestrr/apps/flock/group/dto/GroupInviteDto.java
+++ b/src/main/java/com/nestrr/apps/flock/group/dto/GroupInviteDto.java
@@ -1,0 +1,6 @@
+package com.nestrr.apps.flock.group.dto;
+
+import java.time.LocalDateTime;
+
+public record GroupInviteDto(
+    String groupId, String personId, LocalDateTime expiresOn, GroupInviteStatusDto status) {}

--- a/src/main/java/com/nestrr/apps/flock/group/dto/GroupInviteStatusDto.java
+++ b/src/main/java/com/nestrr/apps/flock/group/dto/GroupInviteStatusDto.java
@@ -1,0 +1,3 @@
+package com.nestrr.apps.flock.group.dto;
+
+public record GroupInviteStatusDto(String id, String name, String description) {}

--- a/src/main/java/com/nestrr/apps/flock/group/dto/GroupStatusDto.java
+++ b/src/main/java/com/nestrr/apps/flock/group/dto/GroupStatusDto.java
@@ -1,0 +1,3 @@
+package com.nestrr.apps.flock.group.dto;
+
+public record GroupStatusDto(String id, String name) {}

--- a/src/main/java/com/nestrr/apps/flock/group/dto/NewGroupInviteRequest.java
+++ b/src/main/java/com/nestrr/apps/flock/group/dto/NewGroupInviteRequest.java
@@ -1,0 +1,5 @@
+package com.nestrr.apps.flock.group.dto;
+
+import java.time.LocalDateTime;
+
+public record NewGroupInviteRequest(String groupId, String recipientId) {}

--- a/src/main/java/com/nestrr/apps/flock/group/dto/NewGroupRequest.java
+++ b/src/main/java/com/nestrr/apps/flock/group/dto/NewGroupRequest.java
@@ -1,0 +1,6 @@
+package com.nestrr.apps.flock.group.dto;
+
+import java.util.List;
+
+public record NewGroupRequest(
+    List<String> members, String name, String description, String image) {}

--- a/src/main/java/com/nestrr/apps/flock/group/entity/Group.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/Group.java
@@ -2,7 +2,6 @@ package com.nestrr.apps.flock.group.entity;
 
 import jakarta.persistence.*;
 import java.util.Objects;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/nestrr/apps/flock/group/entity/Group.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/Group.java
@@ -1,0 +1,45 @@
+package com.nestrr.apps.flock.group.entity;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+public record Group(
+    @Id @GeneratedValue(strategy = GenerationType.UUID) String id,
+    @Version Integer version,
+    String name,
+    String description,
+    String image,
+    String adminId,
+    String statusId) {
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) return true;
+    if (other == null) return false;
+    if (other
+        instanceof
+        Group(
+            String id1,
+            Integer version1,
+            String name1,
+            String description1,
+            String image1,
+            String adminId1,
+            String statusId1)) {
+      return id1.equals(id)
+          && version1.equals(version)
+          && name1.equals(name)
+          && description1.equals(description)
+          && image1.equals((image))
+          && adminId1.equals(adminId)
+          && statusId1.equals(statusId);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, version, name, description, image, adminId, statusId);
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/entity/Group.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/Group.java
@@ -3,37 +3,41 @@ package com.nestrr.apps.flock.group.entity;
 import jakarta.persistence.*;
 import java.util.Objects;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 @Entity
-public record Group(
-    @Id @GeneratedValue(strategy = GenerationType.UUID) String id,
-    @Version Integer version,
-    String name,
-    String description,
-    String image,
-    String adminId,
-    String statusId) {
+@Builder
+@Data
+@Table(name = "\"group\"")
+@NoArgsConstructor
+@AllArgsConstructor
+public final class Group {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
+
+  @Version private Integer version;
+  private String name;
+  private String description;
+  private String image;
+  private String adminId;
+  private String statusId;
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (other == null) return false;
-    if (other
-        instanceof
-        Group(
-            String id1,
-            Integer version1,
-            String name1,
-            String description1,
-            String image1,
-            String adminId1,
-            String statusId1)) {
-      return id1.equals(id)
-          && version1.equals(version)
-          && name1.equals(name)
-          && description1.equals(description)
-          && image1.equals((image))
-          && adminId1.equals(adminId)
-          && statusId1.equals(statusId);
+    if (other instanceof Group otherGroup) {
+      return otherGroup.getId().equals(id)
+          && otherGroup.getVersion().equals(version)
+          && otherGroup.getName().equals(name)
+          && otherGroup.getDescription().equals(description)
+          && otherGroup.getImage().equals((image))
+          && otherGroup.getAdminId().equals(adminId)
+          && otherGroup.getStatusId().equals(statusId);
     }
     return false;
   }

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupInvite.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupInvite.java
@@ -4,29 +4,31 @@ import com.nestrr.apps.flock.group.entity.id.GroupInviteId;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
-public record GroupInvite(
-    @EmbeddedId GroupInviteId id,
-    @Version Integer version,
-    String statusId,
-    LocalDateTime expiresOn) {
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public final class GroupInvite {
+  @EmbeddedId private GroupInviteId id;
+  @Version private Integer version;
+  private String statusId;
+  private LocalDateTime expiresOn;
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (other == null) return false;
-    if (other
-        instanceof
-        GroupInvite(
-            GroupInviteId id1,
-            Integer version1,
-            String statusId1,
-            LocalDateTime expiresOn1)) {
-      return id1.equals(id)
-          && version1.equals(version)
-          && statusId1.equals((statusId))
-          && expiresOn1.isEqual(expiresOn);
+    if (other instanceof GroupInvite otherGroupInvite) {
+      return otherGroupInvite.getId().equals(id)
+          && otherGroupInvite.getVersion().equals(version)
+          && otherGroupInvite.getStatusId().equals((statusId))
+          && otherGroupInvite.getExpiresOn().isEqual(expiresOn);
     }
     return false;
   }

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupInvite.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupInvite.java
@@ -1,0 +1,38 @@
+package com.nestrr.apps.flock.group.entity;
+
+import com.nestrr.apps.flock.group.entity.id.GroupInviteId;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+public record GroupInvite(
+    @EmbeddedId GroupInviteId id,
+    @Version Integer version,
+    String statusId,
+    LocalDateTime expiresOn) {
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) return true;
+    if (other == null) return false;
+    if (other
+        instanceof
+        GroupInvite(
+            GroupInviteId id1,
+            Integer version1,
+            String statusId1,
+            LocalDateTime expiresOn1)) {
+      return id1.equals(id)
+          && version1.equals(version)
+          && statusId1.equals((statusId))
+          && expiresOn1.isEqual(expiresOn);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, version, statusId, expiresOn);
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupInviteStatus.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupInviteStatus.java
@@ -1,0 +1,32 @@
+package com.nestrr.apps.flock.group.entity;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+public record GroupInviteStatus(
+    @Id @GeneratedValue(strategy = GenerationType.UUID) String id,
+    @Version Integer version,
+    String name,
+    String description) {
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) return true;
+    if (other == null) return false;
+    if (other
+        instanceof
+        GroupInviteStatus(String id1, Integer version1, String name1, String description1)) {
+      return id1.equals(id)
+          && version1.equals(version)
+          && name1.equals(name)
+          && description1.equals(description);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, version, name, description);
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupInviteStatus.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupInviteStatus.java
@@ -1,26 +1,35 @@
 package com.nestrr.apps.flock.group.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import net.jcip.annotations.Immutable;
+
 import java.util.Objects;
 
 @Entity
-public record GroupInviteStatus(
-    @Id @GeneratedValue(strategy = GenerationType.UUID) String id,
-    @Version Integer version,
-    String name,
-    String description) {
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public final class GroupInviteStatus {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
+
+  @Version private Integer version;
+  private String name;
+  private String description;
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (other == null) return false;
-    if (other
-        instanceof
-        GroupInviteStatus(String id1, Integer version1, String name1, String description1)) {
-      return id1.equals(id)
-          && version1.equals(version)
-          && name1.equals(name)
-          && description1.equals(description);
+    if (other instanceof GroupInviteStatus otherGroupInviteStatus) {
+      return otherGroupInviteStatus.id.equals(id)
+          && otherGroupInviteStatus.version.equals(version)
+          && otherGroupInviteStatus.name.equals(name)
+          && otherGroupInviteStatus.description.equals(description);
     }
     return false;
   }

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupMembership.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupMembership.java
@@ -2,17 +2,27 @@ package com.nestrr.apps.flock.group.entity;
 
 import com.nestrr.apps.flock.group.entity.id.GroupMembershipId;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.util.Objects;
 
 @Entity
-public record GroupMembership(@EmbeddedId GroupMembershipId id, @Version Integer version) {
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public final class GroupMembership {
+  @EmbeddedId private GroupMembershipId id;
+  @Version private Integer version;
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (other == null) return false;
-    if (other instanceof GroupMembership(GroupMembershipId id1, Integer version1)) {
-      return id1.equals(id) && version1.equals(version);
+    if (other instanceof GroupMembership otherGroupMembership) {
+      return otherGroupMembership.getId().equals(id)
+          && otherGroupMembership.getVersion().equals(version);
     }
     return false;
   }

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupMembership.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupMembership.java
@@ -1,0 +1,24 @@
+package com.nestrr.apps.flock.group.entity;
+
+import com.nestrr.apps.flock.group.entity.id.GroupMembershipId;
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+public record GroupMembership(@EmbeddedId GroupMembershipId id, @Version Integer version) {
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) return true;
+    if (other == null) return false;
+    if (other instanceof GroupMembership(GroupMembershipId id1, Integer version1)) {
+      return id1.equals(id) && version1.equals(version);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, version);
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupStatus.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupStatus.java
@@ -2,24 +2,34 @@ package com.nestrr.apps.flock.group.entity;
 
 import jakarta.persistence.*;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
-public record GroupStatus(
-    @Id @GeneratedValue(strategy = GenerationType.UUID) String id,
-    @Version Integer version,
-    String name,
-    String description) {
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public final class GroupStatus {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
+
+  @Version private Integer version;
+  private String name;
+  private String description;
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (other == null) return false;
-    if (other
-        instanceof GroupStatus(String id1, Integer version1, String name1, String description1)) {
-      return id1.equals(id)
-          && version1.equals(version)
-          && name1.equals(name)
-          && description1.equals(description);
+    if (other instanceof GroupStatus otherStatus) {
+      return otherStatus.getId().equals(id)
+          && otherStatus.getVersion().equals(version)
+          && otherStatus.getName().equals(name)
+          && otherStatus.getDescription().equals(description);
     }
     return false;
   }

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupStatus.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupStatus.java
@@ -1,0 +1,31 @@
+package com.nestrr.apps.flock.group.entity;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+public record GroupStatus(
+    @Id @GeneratedValue(strategy = GenerationType.UUID) String id,
+    @Version Integer version,
+    String name,
+    String description) {
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) return true;
+    if (other == null) return false;
+    if (other
+        instanceof GroupStatus(String id1, Integer version1, String name1, String description1)) {
+      return id1.equals(id)
+          && version1.equals(version)
+          && name1.equals(name)
+          && description1.equals(description);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, version, name, description);
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupView.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupView.java
@@ -1,0 +1,50 @@
+package com.nestrr.apps.flock.group.entity;
+
+import com.nestrr.apps.flock.group.dto.GroupStatusDto;
+import jakarta.persistence.*;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.Immutable;
+
+@Entity
+@Data
+@Immutable
+@NoArgsConstructor
+@AllArgsConstructor
+public final class GroupView {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
+
+  private String name;
+  private String description;
+  private String image;
+  private String adminId;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  private GroupStatusDto status;
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) return true;
+    if (other == null) return false;
+    if (other instanceof GroupView otherGroupView) {
+      return otherGroupView.getId().equals(id)
+          && otherGroupView.getName().equals(name)
+          && otherGroupView.getDescription().equals(description)
+          && otherGroupView.getImage().equals((image))
+          && otherGroupView.getAdminId().equals(adminId)
+          && otherGroupView.getStatus().equals(status);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, description, image, adminId, status);
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/entity/id/GroupInviteId.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/id/GroupInviteId.java
@@ -1,0 +1,25 @@
+package com.nestrr.apps.flock.group.entity.id;
+
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.time.LocalTime;
+import java.util.Objects;
+
+@Embeddable
+public record GroupInviteId(String groupId, String personId) implements Serializable {
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) return true;
+    if (obj instanceof GroupInviteId(String groupId1, String personId1)) {
+      return groupId1.equals(groupId) && personId1.equals(personId);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(groupId, personId);
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/entity/id/GroupMembershipId.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/id/GroupMembershipId.java
@@ -1,0 +1,23 @@
+package com.nestrr.apps.flock.group.entity.id;
+
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public record GroupMembershipId(String groupId, String personId) implements Serializable {
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) return true;
+    if (obj instanceof GroupMembershipId(String groupId1, String personId1)) {
+      return groupId1.equals(groupId) && personId1.equals(personId);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(groupId, personId);
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/mapper/GroupMapper.java
+++ b/src/main/java/com/nestrr/apps/flock/group/mapper/GroupMapper.java
@@ -1,0 +1,13 @@
+package com.nestrr.apps.flock.group.mapper;
+
+import com.nestrr.apps.flock.group.dto.GroupDto;
+import com.nestrr.apps.flock.group.entity.GroupView;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.springframework.stereotype.Component;
+
+@Component
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE, componentModel = "spring")
+public interface GroupMapper {
+  GroupDto toGroupDto(GroupView groupView);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupInviteRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupInviteRepository.java
@@ -2,9 +2,16 @@ package com.nestrr.apps.flock.group.repository;
 
 import com.nestrr.apps.flock.group.entity.GroupInvite;
 import com.nestrr.apps.flock.group.entity.id.GroupInviteId;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.ListPagingAndSortingRepository;
 
+import java.util.List;
+
 public interface GroupInviteRepository
     extends ListPagingAndSortingRepository<GroupInvite, GroupInviteId>,
-        ListCrudRepository<GroupInvite, GroupInviteId> {}
+        ListCrudRepository<GroupInvite, GroupInviteId>,
+        JpaRepository<GroupInvite, GroupInviteId> {
+
+  List<GroupInvite> findByIdGroupId(String groupId);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupInviteRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupInviteRepository.java
@@ -1,0 +1,10 @@
+package com.nestrr.apps.flock.group.repository;
+
+import com.nestrr.apps.flock.group.entity.GroupInvite;
+import com.nestrr.apps.flock.group.entity.id.GroupInviteId;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
+
+public interface GroupInviteRepository
+    extends ListPagingAndSortingRepository<GroupInvite, GroupInviteId>,
+        ListCrudRepository<GroupInvite, GroupInviteId> {}

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupInviteStatusRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupInviteStatusRepository.java
@@ -1,0 +1,9 @@
+package com.nestrr.apps.flock.group.repository;
+
+import com.nestrr.apps.flock.group.entity.GroupInviteStatus;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
+
+public interface GroupInviteStatusRepository
+    extends ListPagingAndSortingRepository<GroupInviteStatus, String>,
+        ListCrudRepository<GroupInviteStatus, String> {}

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupInviteStatusRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupInviteStatusRepository.java
@@ -1,9 +1,15 @@
 package com.nestrr.apps.flock.group.repository;
 
 import com.nestrr.apps.flock.group.entity.GroupInviteStatus;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.ListPagingAndSortingRepository;
 
+import java.util.Optional;
+
 public interface GroupInviteStatusRepository
     extends ListPagingAndSortingRepository<GroupInviteStatus, String>,
-        ListCrudRepository<GroupInviteStatus, String> {}
+        ListCrudRepository<GroupInviteStatus, String> {
+  @Query(nativeQuery = true, value = "SELECT * FROM group_invite_status gs WHERE gs.name=?1")
+  Optional<GroupInviteStatus> findByName(String name);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupMembershipRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupMembershipRepository.java
@@ -1,0 +1,10 @@
+package com.nestrr.apps.flock.group.repository;
+
+import com.nestrr.apps.flock.group.entity.GroupMembership;
+import com.nestrr.apps.flock.group.entity.id.GroupMembershipId;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
+
+public interface GroupMembershipRepository
+    extends ListPagingAndSortingRepository<GroupMembership, GroupMembershipId>,
+        ListCrudRepository<GroupMembership, GroupMembershipId> {}

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupRepository.java
@@ -1,0 +1,8 @@
+package com.nestrr.apps.flock.group.repository;
+
+import com.nestrr.apps.flock.group.entity.Group;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
+
+public interface GroupRepository
+    extends ListPagingAndSortingRepository<Group, String>, ListCrudRepository<Group, String> {}

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupRepository.java
@@ -1,8 +1,13 @@
 package com.nestrr.apps.flock.group.repository;
 
 import com.nestrr.apps.flock.group.entity.Group;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.ListPagingAndSortingRepository;
 
 public interface GroupRepository
-    extends ListPagingAndSortingRepository<Group, String>, ListCrudRepository<Group, String> {}
+    extends ListPagingAndSortingRepository<Group, String>, ListCrudRepository<Group, String> {
+  @Query(nativeQuery = true, value = "SELECT * FROM \"group\" g WHERE g.admin_id=?1")
+  List<Group> findByAdminId(String adminId);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupStatusRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupStatusRepository.java
@@ -1,9 +1,16 @@
 package com.nestrr.apps.flock.group.repository;
 
 import com.nestrr.apps.flock.group.entity.GroupStatus;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.ListPagingAndSortingRepository;
 
+import java.util.Optional;
+
 public interface GroupStatusRepository
     extends ListPagingAndSortingRepository<GroupStatus, String>,
-        ListCrudRepository<GroupStatus, String> {}
+        ListCrudRepository<GroupStatus, String> {
+
+  @Query(nativeQuery = true, value = "SELECT * FROM group_status gs WHERE gs.name=?1")
+  Optional<GroupStatus> findByName(String name);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupStatusRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupStatusRepository.java
@@ -1,0 +1,9 @@
+package com.nestrr.apps.flock.group.repository;
+
+import com.nestrr.apps.flock.group.entity.GroupStatus;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
+
+public interface GroupStatusRepository
+    extends ListPagingAndSortingRepository<GroupStatus, String>,
+        ListCrudRepository<GroupStatus, String> {}

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeService.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeService.java
@@ -1,0 +1,8 @@
+package com.nestrr.apps.flock.group.service;
+
+import com.nestrr.apps.flock.group.dto.NewGroupRequest;
+import org.springframework.security.core.Authentication;
+
+public interface GroupFacadeService {
+  void createGroup(Authentication auth, NewGroupRequest newGroupRequest);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeServiceImpl.java
@@ -3,6 +3,8 @@ package com.nestrr.apps.flock.group.service;
 import static com.nestrr.apps.flock.util.AuthenticationUtil.getJwtId;
 
 import com.nestrr.apps.flock.group.dto.NewGroupRequest;
+import com.nestrr.apps.flock.group.entity.Group;
+import java.util.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,8 +22,9 @@ public class GroupFacadeServiceImpl implements GroupFacadeService {
   @Override
   @Transactional
   public void createGroup(Authentication auth, NewGroupRequest newGroupRequest) {
-    String id = getJwtId(auth);
-    String groupId = groupService.createGroup(id, newGroupRequest);
-    groupInviteService.createInvites(groupId, newGroupRequest.members());
+    String creatorId = getJwtId(auth);
+    Group group = groupService.createGroup(creatorId, newGroupRequest);
+    groupInviteService.createInvites(group, newGroupRequest.members());
+    groupMembershipService.addMember(group.getId(), creatorId);
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeServiceImpl.java
@@ -1,0 +1,27 @@
+package com.nestrr.apps.flock.group.service;
+
+import static com.nestrr.apps.flock.util.AuthenticationUtil.getJwtId;
+
+import com.nestrr.apps.flock.group.dto.NewGroupRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GroupFacadeServiceImpl implements GroupFacadeService {
+  private final GroupService groupService;
+  private final GroupInviteService groupInviteService;
+
+  public GroupFacadeServiceImpl(GroupService groupService, GroupInviteService groupInviteService) {
+    this.groupService = groupService;
+    this.groupInviteService = groupInviteService;
+  }
+
+  @Override
+  @Transactional
+  public void createGroup(Authentication auth, NewGroupRequest newGroupRequest) {
+    String id = getJwtId(auth);
+    String groupId = groupService.createGroup(id, newGroupRequest);
+    groupInviteService.createInvites(groupId, newGroupRequest.members());
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupInviteService.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupInviteService.java
@@ -1,10 +1,11 @@
 package com.nestrr.apps.flock.group.service;
 
 import com.nestrr.apps.flock.group.dto.NewGroupInviteRequest;
+import com.nestrr.apps.flock.group.entity.Group;
 import java.util.List;
 
 public interface GroupInviteService {
   void createInvites(NewGroupInviteRequest request);
 
-  void createInvites(String groupId, List<String> recipientIds);
+  void createInvites(Group group, List<String> recipientIds);
 }

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupInviteService.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupInviteService.java
@@ -1,0 +1,10 @@
+package com.nestrr.apps.flock.group.service;
+
+import com.nestrr.apps.flock.group.dto.NewGroupInviteRequest;
+import java.util.List;
+
+public interface GroupInviteService {
+  void createInvites(NewGroupInviteRequest request);
+
+  void createInvites(String groupId, List<String> recipientIds);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupInviteServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupInviteServiceImpl.java
@@ -3,11 +3,16 @@ package com.nestrr.apps.flock.group.service;
 import com.nestrr.apps.flock.group.constants.GroupInviteConstants;
 import com.nestrr.apps.flock.group.constants.GroupInviteStatuses;
 import com.nestrr.apps.flock.group.dto.NewGroupInviteRequest;
+import com.nestrr.apps.flock.group.entity.Group;
 import com.nestrr.apps.flock.group.entity.GroupInvite;
 import com.nestrr.apps.flock.group.entity.GroupInviteStatus;
 import com.nestrr.apps.flock.group.entity.id.GroupInviteId;
 import com.nestrr.apps.flock.group.repository.GroupInviteRepository;
 import com.nestrr.apps.flock.group.repository.GroupInviteStatusRepository;
+import com.nestrr.apps.flock.messaging.dto.GroupInviteContext;
+import com.nestrr.apps.flock.messaging.service.MessagingService;
+import com.nestrr.apps.flock.profile.entity.Person;
+import com.nestrr.apps.flock.profile.repository.PersonRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -18,12 +23,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class GroupInviteServiceImpl implements GroupInviteService {
   private final GroupInviteRepository groupInviteRepository;
   private final GroupInviteStatusRepository groupInviteStatusRepository;
+  private final PersonRepository personRepository;
+  private final MessagingService messagingService;
 
   public GroupInviteServiceImpl(
       GroupInviteRepository groupInviteRepository,
-      GroupInviteStatusRepository groupInviteStatusRepository) {
+      GroupInviteStatusRepository groupInviteStatusRepository,
+      MessagingService messagingService,
+      PersonRepository personRepository) {
     this.groupInviteRepository = groupInviteRepository;
     this.groupInviteStatusRepository = groupInviteStatusRepository;
+    this.messagingService = messagingService;
+    this.personRepository = personRepository;
   }
 
   @Transactional
@@ -34,8 +45,10 @@ public class GroupInviteServiceImpl implements GroupInviteService {
 
   @Transactional
   @Override
-  public void createInvites(String groupId, List<String> recipientIds) {
-    recipientIds.forEach(id -> storeInvite(groupId, id, getPendingStatusId()));
+  public void createInvites(Group group, List<String> recipientIds) {
+    recipientIds.forEach(
+        recipientId -> storeInvite(group.getId(), recipientId, getPendingStatusId()));
+    sendInvites(group, recipientIds);
   }
 
   private void storeInvite(String groupId, String recipientId, String statusId) {
@@ -58,5 +71,20 @@ public class GroupInviteServiceImpl implements GroupInviteService {
                 new NoSuchElementException(
                     String.format(
                         "No appropriate group invite status ID found for status: %s.", pending)));
+  }
+
+  private void sendInvites(Group group, List<String> recipientIds) {
+    Person admin =
+        personRepository
+            .findById(group.getAdminId())
+            .orElseThrow(
+                () ->
+                    new NoSuchElementException(
+                        String.format(
+                            "No Person object found for admin ID %s (group ID %s)",
+                            group.getAdminId(), group.getId())));
+
+    GroupInviteContext context = GroupInviteContext.builder().group(group).admin(admin).build();
+    messagingService.sendInviteNotification(context, recipientIds);
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupInviteServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupInviteServiceImpl.java
@@ -1,0 +1,62 @@
+package com.nestrr.apps.flock.group.service;
+
+import com.nestrr.apps.flock.group.constants.GroupInviteConstants;
+import com.nestrr.apps.flock.group.constants.GroupInviteStatuses;
+import com.nestrr.apps.flock.group.dto.NewGroupInviteRequest;
+import com.nestrr.apps.flock.group.entity.GroupInvite;
+import com.nestrr.apps.flock.group.entity.GroupInviteStatus;
+import com.nestrr.apps.flock.group.entity.id.GroupInviteId;
+import com.nestrr.apps.flock.group.repository.GroupInviteRepository;
+import com.nestrr.apps.flock.group.repository.GroupInviteStatusRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GroupInviteServiceImpl implements GroupInviteService {
+  private final GroupInviteRepository groupInviteRepository;
+  private final GroupInviteStatusRepository groupInviteStatusRepository;
+
+  public GroupInviteServiceImpl(
+      GroupInviteRepository groupInviteRepository,
+      GroupInviteStatusRepository groupInviteStatusRepository) {
+    this.groupInviteRepository = groupInviteRepository;
+    this.groupInviteStatusRepository = groupInviteStatusRepository;
+  }
+
+  @Transactional
+  @Override
+  public void createInvites(NewGroupInviteRequest request) {
+    this.storeInvite(request.groupId(), request.recipientId(), getPendingStatusId());
+  }
+
+  @Transactional
+  @Override
+  public void createInvites(String groupId, List<String> recipientIds) {
+    recipientIds.forEach(id -> storeInvite(groupId, id, getPendingStatusId()));
+  }
+
+  private void storeInvite(String groupId, String recipientId, String statusId) {
+    groupInviteRepository.save(
+        GroupInvite.builder()
+            .id(new GroupInviteId(groupId, recipientId))
+            .statusId(statusId)
+            .expiresOn(LocalDateTime.now().plusDays(GroupInviteConstants.INVITE_WAIT_PERIOD_DAYS))
+            .build());
+  }
+
+  private String getPendingStatusId() {
+    String pending = GroupInviteStatuses.RESPONSE_PENDING.value();
+
+    return groupInviteStatusRepository
+        .findByName(pending)
+        .map(GroupInviteStatus::getId)
+        .orElseThrow(
+            () ->
+                new NoSuchElementException(
+                    String.format(
+                        "No appropriate group invite status ID found for status: %s.", pending)));
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupService.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupService.java
@@ -1,7 +1,8 @@
 package com.nestrr.apps.flock.group.service;
 
 import com.nestrr.apps.flock.group.dto.NewGroupRequest;
+import com.nestrr.apps.flock.group.entity.Group;
 
 public interface GroupService {
-  String createGroup(String creatorId, NewGroupRequest newGroupRequest);
+  Group createGroup(String creatorId, NewGroupRequest newGroupRequest);
 }

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupService.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupService.java
@@ -1,0 +1,7 @@
+package com.nestrr.apps.flock.group.service;
+
+import com.nestrr.apps.flock.group.dto.NewGroupRequest;
+
+public interface GroupService {
+  String createGroup(String creatorId, NewGroupRequest newGroupRequest);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupServiceImpl.java
@@ -23,7 +23,7 @@ public class GroupServiceImpl implements GroupService {
 
   @Override
   @Transactional
-  public String createGroup(String creatorId, NewGroupRequest newGroupRequest) {
+  public Group createGroup(String creatorId, NewGroupRequest newGroupRequest) {
     String pending = GroupStatuses.PENDING.value();
 
     String pendingStatusId =
@@ -34,15 +34,13 @@ public class GroupServiceImpl implements GroupService {
                 () ->
                     new NoSuchElementException(
                         "No appropriate group status ID found for status: pending."));
-    return groupRepository
-        .save(
-            Group.builder()
-                .name(newGroupRequest.name())
-                .description(newGroupRequest.description())
-                .image(newGroupRequest.image())
-                .adminId(creatorId)
-                .statusId(pendingStatusId)
-                .build())
-        .getId();
+    return groupRepository.save(
+        Group.builder()
+            .name(newGroupRequest.name())
+            .description(newGroupRequest.description())
+            .image(newGroupRequest.image())
+            .adminId(creatorId)
+            .statusId(pendingStatusId)
+            .build());
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupServiceImpl.java
@@ -1,0 +1,48 @@
+package com.nestrr.apps.flock.group.service;
+
+import com.nestrr.apps.flock.group.constants.GroupStatuses;
+import com.nestrr.apps.flock.group.dto.NewGroupRequest;
+import com.nestrr.apps.flock.group.entity.Group;
+import com.nestrr.apps.flock.group.entity.GroupStatus;
+import com.nestrr.apps.flock.group.repository.GroupRepository;
+import com.nestrr.apps.flock.group.repository.GroupStatusRepository;
+import java.util.NoSuchElementException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GroupServiceImpl implements GroupService {
+  private final GroupRepository groupRepository;
+  private final GroupStatusRepository groupStatusRepository;
+
+  public GroupServiceImpl(
+      GroupRepository groupRepository, GroupStatusRepository groupStatusRepository) {
+    this.groupRepository = groupRepository;
+    this.groupStatusRepository = groupStatusRepository;
+  }
+
+  @Override
+  @Transactional
+  public String createGroup(String creatorId, NewGroupRequest newGroupRequest) {
+    String pending = GroupStatuses.PENDING.value();
+
+    String pendingStatusId =
+        groupStatusRepository
+            .findByName(pending)
+            .map(GroupStatus::getId)
+            .orElseThrow(
+                () ->
+                    new NoSuchElementException(
+                        "No appropriate group status ID found for status: pending."));
+    return groupRepository
+        .save(
+            Group.builder()
+                .name(newGroupRequest.name())
+                .description(newGroupRequest.description())
+                .image(newGroupRequest.image())
+                .adminId(creatorId)
+                .statusId(pendingStatusId)
+                .build())
+        .getId();
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/messaging/dto/GroupInviteContext.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/dto/GroupInviteContext.java
@@ -1,0 +1,8 @@
+package com.nestrr.apps.flock.messaging.dto;
+
+import com.nestrr.apps.flock.group.entity.Group;
+import com.nestrr.apps.flock.profile.entity.Person;
+import lombok.Builder;
+
+@Builder
+public record GroupInviteContext(Group group, Person admin) {}

--- a/src/main/java/com/nestrr/apps/flock/messaging/dto/MultiRecipientGroupInvite.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/dto/MultiRecipientGroupInvite.java
@@ -1,0 +1,5 @@
+package com.nestrr.apps.flock.messaging.dto;
+
+import java.util.List;
+
+public record MultiRecipientGroupInvite(GroupInviteContext context, List<String> recipientIds) {}

--- a/src/main/java/com/nestrr/apps/flock/messaging/entity/Email.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/entity/Email.java
@@ -1,0 +1,28 @@
+package com.nestrr.apps.flock.messaging.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public final class Email {
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  private String id;
+
+  @Version private Integer version;
+  private List<String> recipients;
+  private final LocalDateTime timestamp = LocalDateTime.now();
+  private String subject;
+  @Builder.Default private String htmlBody = "";
+  @Builder.Default private String textBody = "";
+  private boolean success;
+}

--- a/src/main/java/com/nestrr/apps/flock/messaging/repository/EmailRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/repository/EmailRepository.java
@@ -1,0 +1,13 @@
+package com.nestrr.apps.flock.messaging.repository;
+
+import com.nestrr.apps.flock.group.entity.GroupInvite;
+import com.nestrr.apps.flock.group.entity.id.GroupInviteId;
+import com.nestrr.apps.flock.messaging.entity.Email;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.ListCrudRepository;
+import org.springframework.data.repository.ListPagingAndSortingRepository;
+
+public interface EmailRepository
+    extends ListPagingAndSortingRepository<Email, String>,
+        ListCrudRepository<Email, String>,
+        JpaRepository<Email, String> {}

--- a/src/main/java/com/nestrr/apps/flock/messaging/service/EmailSender.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/service/EmailSender.java
@@ -1,0 +1,8 @@
+package com.nestrr.apps.flock.messaging.service;
+
+import com.nestrr.apps.flock.messaging.entity.Email;
+
+public interface EmailSender {
+
+  void sendSystemEmail(Email email);
+}

--- a/src/main/java/com/nestrr/apps/flock/messaging/service/EmailSenderImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/service/EmailSenderImpl.java
@@ -1,0 +1,47 @@
+package com.nestrr.apps.flock.messaging.service;
+
+import com.nestrr.apps.flock.messaging.entity.Email;
+import com.nestrr.apps.flock.messaging.repository.EmailRepository;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.MailSendException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailSenderImpl implements EmailSender {
+
+  private final JavaMailSender mailSender;
+  private final EmailRepository emailRepository;
+
+  @Value("${spring.mail.username}")
+  private String systemEmailAddress;
+
+  public EmailSenderImpl(JavaMailSender mailSender, EmailRepository emailRepository) {
+    this.mailSender = mailSender;
+    this.emailRepository = emailRepository;
+  }
+
+  @Override
+  public void sendSystemEmail(Email email) {
+    MimeMessage message = this.mailSender.createMimeMessage();
+    try {
+      MimeMessageHelper messageHelper =
+          new MimeMessageHelper(message, MimeMessageHelper.MULTIPART_MODE_MIXED, "UTF-8");
+
+      messageHelper.setFrom(systemEmailAddress);
+      messageHelper.setTo(email.getRecipients().toArray(new String[] {}));
+      messageHelper.setSubject(email.getSubject());
+      messageHelper.setText(email.getTextBody(), email.getHtmlBody());
+      this.mailSender.send(message);
+    } catch (Exception e) {
+      email.setSuccess(false);
+      emailRepository.save(email);
+      throw new MailSendException(
+          String.format("System email could not be sent to %s.", email.getRecipients().toString()));
+    }
+    email.setSuccess(true);
+    emailRepository.save(email);
+  }
+}

--- a/src/main/java/com/nestrr/apps/flock/messaging/service/MessagingService.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/service/MessagingService.java
@@ -1,0 +1,9 @@
+package com.nestrr.apps.flock.messaging.service;
+
+import com.nestrr.apps.flock.messaging.dto.GroupInviteContext;
+import java.util.List;
+
+public interface MessagingService {
+
+  void sendInviteNotification(GroupInviteContext context, List<String> recipientIds);
+}

--- a/src/main/java/com/nestrr/apps/flock/messaging/service/MessagingServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/service/MessagingServiceImpl.java
@@ -1,0 +1,70 @@
+package com.nestrr.apps.flock.messaging.service;
+
+import com.nestrr.apps.flock.messaging.dto.GroupInviteContext;
+import com.nestrr.apps.flock.messaging.entity.Email;
+import com.nestrr.apps.flock.profile.entity.Person;
+import com.nestrr.apps.flock.profile.repository.PersonRepository;
+import java.util.List;
+import java.util.Locale;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.ISpringTemplateEngine;
+
+@Service
+public class MessagingServiceImpl implements MessagingService {
+  private final ISpringTemplateEngine emailTemplateEngine;
+  private final EmailSender emailService;
+  private final PersonRepository personRepository;
+
+  @Value("${frontend.url}")
+  private String frontend;
+
+  public MessagingServiceImpl(
+      EmailSender emailService,
+      PersonRepository personRepository,
+      ISpringTemplateEngine emailTemplateEngine) {
+    this.emailService = emailService;
+    this.personRepository = personRepository;
+    this.emailTemplateEngine = emailTemplateEngine;
+  }
+
+  @Override
+  public void sendInviteNotification(GroupInviteContext context, List<String> recipientIds) {
+    recipientIds.forEach(
+        id -> {
+          String emailAddress =
+              personRepository
+                  .findById(id)
+                  .map(Person::getEmail)
+                  .orElseThrow(
+                      () ->
+                          new NullPointerException(
+                              String.format("Person with ID %s does not have an email", id)));
+          Email email = createInviteEmail(context, id, emailAddress);
+          emailService.sendSystemEmail(email);
+        });
+  }
+
+  public Email createInviteEmail(
+      GroupInviteContext context, String recipientId, String recipientEmail) {
+    String subject =
+        String.format("You're invited to a new group on Nestrr: %s!", context.group().getName());
+    Context ctx = new Context(Locale.US);
+    ctx.setVariable("pageTitle", subject);
+    ctx.setVariable("groupName", context.group().getName());
+    ctx.setVariable("groupId", context.group().getId());
+    ctx.setVariable("adminId", context.admin().getId());
+    ctx.setVariable("adminName", context.admin().getName());
+    ctx.setVariable(
+        "inviteUrl",
+        String.format("%s/invite/%s?id=%s", frontend, context.group().getId(), recipientId));
+
+    String content = emailTemplateEngine.process("group-invite/template.html", ctx);
+    return Email.builder()
+        .subject(subject)
+        .htmlBody(content)
+        .recipients(List.of(recipientEmail))
+        .build();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,22 @@
+frontend:
+  url: http://localhost:3000
 oidc:
   config:
     url: https://login.microsoftonline.com/${MICROSOFT_ENTRA_TENANT_ID}/v2.0/.well-known/openid-configuration
   jwk:
     url: https://login.microsoftonline.com/${MICROSOFT_ENTRA_TENANT_ID}/discovery/v2.0/keys
 spring:
+  mail:
+    host: smtp-mail.outlook.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            required: true
   liquibase:
     contexts: dev # Set to 'dev, seed' in order to seed profiles.
   application:

--- a/src/main/resources/db/changelog/changelog-1.0/changelog-1.0.4.yaml
+++ b/src/main/resources/db/changelog/changelog-1.0/changelog-1.0.4.yaml
@@ -293,3 +293,21 @@ databaseChangeLog:
             referencedColumnNames: id
             onDelete: CASCADE
             onUpdate: CASCADE
+  - changeSet:
+      # Create the profile view
+      id: 202503091626
+      author: maryamkhan
+      runOnChange: true
+      changes:
+        - createView:
+            replaceIfExists: true
+            viewName: group_view
+            selectQuery: |
+              SELECT g.id, 
+                      g.name, 
+                      g.description, 
+                      g.image, 
+                      g.admin_id, 
+                      jsonb_build_object('id', gs.id, 'name', gs.name) AS status
+              FROM "group" g
+              JOIN group_status gs ON g.status_id = gs.id;

--- a/src/main/resources/db/changelog/changelog-1.0/changelog-1.0.4.yaml
+++ b/src/main/resources/db/changelog/changelog-1.0/changelog-1.0.4.yaml
@@ -1,0 +1,295 @@
+databaseChangeLog:
+  - changeSet:
+      # Create the group_invite_status table
+      id: 202503091435
+      author: maryamkhan
+      runOnChange: true
+      changes:
+        - createTable:
+            tableName: group_invite_status
+            columns:
+              - column:
+                  name: id
+                  type: text
+                  defaultValueComputed: gen_random_uuid()::text
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_group_invite_status
+                    nullable: false
+              - column:
+                  name: version
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: text
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            columnNames: name
+            tableName: group_invite_status
+            constraintName: group_invite_status_unique_name
+  - changeSet:
+      # Create the group_status table
+      id: 202503091439
+      author: maryamkhan
+      runOnChange: true
+      changes:
+        - createTable:
+            tableName: group_status
+            columns:
+              - column:
+                  name: id
+                  type: text
+                  defaultValueComputed: gen_random_uuid()::text
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_group_status
+                    nullable: false
+              - column:
+                  name: version
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: text
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            columnNames: name
+            tableName: group_status
+            constraintName: group_status_unique_name
+  - changeSet:
+      # Seed the group_invite_status table.
+      id: 202503091440
+      author: maryamkhan
+      runOnChange: true
+      changes:
+        - loadData:
+            columns:
+              - column:
+                  index: 0
+                  name: version
+                  type: numeric
+              - column:
+                  index: 1
+                  name: name
+                  type: string
+              - column:
+                  index: 2
+                  name: description
+                  type: string
+            encoding: UTF-8
+            file: ../seed/group_invite_status.csv
+            relativeToChangelogFile: true
+            tableName: group_invite_status
+            quotchar: '"'
+            usePreparedStatements: true
+  - changeSet:
+      # Seed the group_status table.
+      id: 202503091441
+      author: maryamkhan
+      runOnChange: true
+      changes:
+        - loadData:
+            columns:
+              - column:
+                  index: 0
+                  name: version
+                  type: numeric
+              - column:
+                  index: 1
+                  name: name
+                  type: string
+              - column:
+                  index: 2
+                  name: description
+                  type: string
+            encoding: UTF-8
+            file: ../seed/group_status.csv
+            relativeToChangelogFile: true
+            tableName: group_status
+            quotchar: '"'
+            usePreparedStatements: true
+  - changeSet:
+      # Create group table.
+      id: 202503091442
+      author: maryamkhan
+      runOnChange: true
+      changes:
+        - createTable:
+            # Create group table
+            tableName: group
+            columns:
+              - column:
+                  name: id
+                  type: text
+                  defaultValueComputed: gen_random_uuid()::text
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_group
+                    nullable: false
+              - column:
+                  name: version
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: image
+                  type: text
+              - column:
+                  name: admin_id
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status_id
+                  type: text
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            constraintName: group_fk_admin_id
+            baseTableName: group
+            baseColumnNames: admin_id
+            referencedTableName: person
+            referencedColumnNames: id
+            onDelete: CASCADE
+            onUpdate: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: group_fk_status_id
+            baseTableName: group
+            baseColumnNames: status_id
+            referencedTableName: group_status
+            referencedColumnNames: id
+            onDelete: CASCADE
+            onUpdate: CASCADE
+  - changeSet:
+      # Create group_invite table.
+      id: 202503091445
+      author: maryamkhan
+      runOnChange: true
+      changes:
+        - createTable:
+            # Create group_invite table
+            tableName: group_invite
+            columns:
+              - column:
+                  name: group_id
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: person_id
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: version
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status_id
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_on
+                  type: datetime
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: group_invite
+            columnNames: group_id, person_id
+            constraintName: pk_group_invite
+        - addForeignKeyConstraint:
+            constraintName: group_invite_fk_status_id
+            baseTableName: group_invite
+            baseColumnNames: status_id
+            referencedTableName: group_invite_status
+            referencedColumnNames: id
+            onDelete: CASCADE
+            onUpdate: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: group_invite_fk_group_id
+            baseTableName: group_invite
+            baseColumnNames: group_id
+            referencedTableName: group
+            referencedColumnNames: id
+            onDelete: CASCADE
+            onUpdate: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: group_invite_fk_person_id
+            baseTableName: group_invite
+            baseColumnNames: person_id
+            referencedTableName: person
+            referencedColumnNames: id
+            onDelete: CASCADE
+            onUpdate: CASCADE
+  - changeSet:
+      # Create group_membership table.
+      id: 202503091448
+      author: maryamkhan
+      runOnChange: true
+      changes:
+        - createTable:
+            # Create group_membership table
+            tableName: group_membership
+            columns:
+              - column:
+                  name: group_id
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: person_id
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: version
+                  type: int
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: group_membership
+            columnNames: group_id, person_id
+            constraintName: pk_group_membership
+        - addForeignKeyConstraint:
+            constraintName: group_membership_fk_group_id
+            baseTableName: group_membership
+            baseColumnNames: group_id
+            referencedTableName: group
+            referencedColumnNames: id
+            onDelete: CASCADE
+            onUpdate: CASCADE
+        - addForeignKeyConstraint:
+            constraintName: group_membership_fk_person_id
+            baseTableName: group_membership
+            baseColumnNames: person_id
+            referencedTableName: person
+            referencedColumnNames: id
+            onDelete: CASCADE
+            onUpdate: CASCADE

--- a/src/main/resources/db/changelog/seed/group_invite_status.csv
+++ b/src/main/resources/db/changelog/seed/group_invite_status.csv
@@ -1,0 +1,5 @@
+version,name,description
+0,"response_pending","Invite sent but response not received."
+0,"expired","Invite expired due to lack of response."
+0,"accepted","Recipient accepted invite."
+0,"rejected","Recipient rejected invite."

--- a/src/main/resources/db/changelog/seed/group_status.csv
+++ b/src/main/resources/db/changelog/seed/group_status.csv
@@ -1,0 +1,3 @@
+version,name,description
+0,"active","Group is being used by at least two members."
+0,"pending","Group has been created but no one has accepted their invite yet."

--- a/src/main/resources/email-templates/group-invite/template.html
+++ b/src/main/resources/email-templates/group-invite/template.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <title th:text="${pageTitle}">Group Invite Template Title</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+
+<body>
+<h1>Hey again! 👋🐦</h1>
+
+<p>You've got a new group invite! <span style="font-weight:bold;" th:text="${adminName}"></span> is inviting you to join
+    <span style="font-weight:bold;" th:text="${groupName}"></span>.</p>
+<p>
+    Here's a little more about the group:
+</p>
+<span style="font-weight:italic;" th:text="${groupDescription}"></span>
+<br/>
+<p>What do you think? <a href="${inviteUrl}" target="_blank">Click here to accept or reject the invite.</a> <b>After a
+    week, your
+    invite will expire, so be sure to accept the invite before then if you're interested!</b></p>
+
+<br/>
+<br/>
+<p>Cheers,</p>
+<p>The Nestrr team</p>
+<!-- ... -->
+</body>
+
+</html>

--- a/src/test/java/com/nestrr/apps/flock/group/GroupControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/group/GroupControllerTest.java
@@ -1,0 +1,67 @@
+package com.nestrr.apps.flock.group;
+
+import static io.restassured.RestAssured.given;
+
+import com.nestrr.apps.flock.group.dto.NewGroupRequest;
+import com.nestrr.apps.flock.group.entity.Group;
+import com.nestrr.apps.flock.group.entity.GroupInvite;
+import com.nestrr.apps.flock.group.repository.GroupInviteRepository;
+import com.nestrr.apps.flock.group.repository.GroupRepository;
+import com.nestrr.apps.flock.profile.entity.Person;
+import com.nestrr.apps.flock.profile.repository.PersonRepository;
+import com.nestrr.apps.flock.shared.AuthenticatedTest;
+import io.restassured.http.ContentType;
+import java.util.List;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class GroupControllerTest extends AuthenticatedTest {
+  @Autowired private GroupRepository groupRepository;
+  @Autowired private GroupInviteRepository groupInviteRepository;
+  @Autowired private PersonRepository personRepository;
+
+  @DynamicPropertySource
+  static void registerPgProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+  }
+
+  @Test
+  @Disabled(value = "Need to set up alternate sender email config for tests to use.")
+  void canCreateGroup() {
+    List<Person> members =
+        List.of(
+            Person.builder().id("a").email("a@gmail.com").name("a").build(),
+            Person.builder().id("b").email("b@gmail.com").name("b").build(),
+            Person.builder().id("c").email("c@gmail.com").name("c").build());
+    personRepository.saveAll(members);
+    NewGroupRequest request =
+        new NewGroupRequest(
+            members.stream().map(Person::getId).toList(),
+            "Test group",
+            "Test description",
+            "Test image");
+    given()
+        .port(getPort())
+        .contentType(ContentType.JSON)
+        .header("Authorization", "Bearer " + getBearerToken())
+        .when()
+        .body(request)
+        .post("/group")
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    List<Group> groupsCreated = groupRepository.findByAdminId(getUserId());
+    Assertions.assertFalse(groupsCreated.isEmpty());
+
+    List<GroupInvite> groupInvitesCreated =
+        groupInviteRepository.findByIdGroupId(groupsCreated.getFirst().getId());
+    Assertions.assertEquals(members.size(), groupInvitesCreated.size());
+  }
+}

--- a/src/test/java/com/nestrr/apps/flock/profile/CampusControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/profile/CampusControllerTest.java
@@ -2,17 +2,19 @@ package com.nestrr.apps.flock.profile;
 
 import static io.restassured.RestAssured.given;
 
-import com.nestrr.apps.flock.profile.dto.OidcProfileRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nestrr.apps.flock.profile.repository.PersonRepository;
+import com.nestrr.apps.flock.profile.repository.RoleAssignmentRepository;
+import com.nestrr.apps.flock.profile.repository.RoleRepository;
+import com.nestrr.apps.flock.shared.AuthenticatedTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.*;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class CampusControllerTest extends AbstractIntegrationTest {
-  @LocalServerPort private int port;
+class CampusControllerTest extends AuthenticatedTest {
 
   @DynamicPropertySource
   static void registerPgProperties(DynamicPropertyRegistry registry) {
@@ -22,27 +24,10 @@ class CampusControllerTest extends AbstractIntegrationTest {
     registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
   }
 
-  private final OidcProfileRequest oidcProfileRequest =
-      OidcProfileRequest.builder().name("Test").email("test@gmail.com").image("image").build();
-
-  @BeforeEach
-  void canCreateProfile() {
-    setBearerToken(oidcProfileRequest.getEmail(), "password");
-    given()
-        .port(port)
-        .contentType(ContentType.JSON)
-        .header("Authorization", "Bearer " + getBearerToken())
-        .when()
-        .body(oidcProfileRequest)
-        .post("/profile/me")
-        .then()
-        .statusCode(HttpStatus.NO_CONTENT.value());
-  }
-
   @Test
   void canGetCampuses() {
     given()
-        .port(port)
+        .port(getPort())
         .contentType(ContentType.JSON)
         .header("Authorization", "Bearer " + getBearerToken())
         .when()

--- a/src/test/java/com/nestrr/apps/flock/profile/DegreeTypeControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/profile/DegreeTypeControllerTest.java
@@ -2,17 +2,19 @@ package com.nestrr.apps.flock.profile;
 
 import static io.restassured.RestAssured.given;
 
-import com.nestrr.apps.flock.profile.dto.OidcProfileRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nestrr.apps.flock.profile.repository.PersonRepository;
+import com.nestrr.apps.flock.profile.repository.RoleAssignmentRepository;
+import com.nestrr.apps.flock.profile.repository.RoleRepository;
+import com.nestrr.apps.flock.shared.AuthenticatedTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.*;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class DegreeTypeControllerTest extends AbstractIntegrationTest {
-  @LocalServerPort private int port;
+class DegreeTypeControllerTest extends AuthenticatedTest {
 
   @DynamicPropertySource
   static void registerPgProperties(DynamicPropertyRegistry registry) {
@@ -22,27 +24,10 @@ class DegreeTypeControllerTest extends AbstractIntegrationTest {
     registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
   }
 
-  private final OidcProfileRequest oidcProfileRequest =
-      OidcProfileRequest.builder().name("Test").email("test@gmail.com").image("image").build();
-
-  @BeforeEach
-  void canCreateProfile() {
-    setBearerToken(oidcProfileRequest.getEmail(), "password");
-    given()
-        .port(port)
-        .contentType(ContentType.JSON)
-        .header("Authorization", "Bearer " + getBearerToken())
-        .when()
-        .body(oidcProfileRequest)
-        .post("/profile/me")
-        .then()
-        .statusCode(HttpStatus.NO_CONTENT.value());
-  }
-
   @Test
   void canGetDegreeTypes() {
     given()
-        .port(port)
+        .port(getPort())
         .contentType(ContentType.JSON)
         .header("Authorization", "Bearer " + getBearerToken())
         .when()

--- a/src/test/java/com/nestrr/apps/flock/profile/HealthControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/profile/HealthControllerTest.java
@@ -3,19 +3,24 @@ package com.nestrr.apps.flock.profile;
 import static io.restassured.RestAssured.given;
 
 import com.nestrr.apps.flock.health.dto.HealthDto;
+import com.nestrr.apps.flock.shared.UnauthenticatedTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
-class HealthControllerTest extends AbstractIntegrationTest {
-  @LocalServerPort private int port;
+class HealthControllerTest extends UnauthenticatedTest {
 
   @Test
   void canGetHealthIfUnauthenticated() {
 
     HealthDto healthDto =
-        given().port(port).contentType(ContentType.JSON).when().get("/health").as(HealthDto.class);
+        given()
+            .port(getPort())
+            .contentType(ContentType.JSON)
+            .when()
+            .get("/health")
+            .as(HealthDto.class);
 
     Assertions.assertTrue(healthDto.isHealth());
   }

--- a/src/test/java/com/nestrr/apps/flock/profile/ProfileControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/profile/ProfileControllerTest.java
@@ -6,18 +6,18 @@ import static org.hamcrest.Matchers.samePropertyValuesAs;
 
 import com.nestrr.apps.flock.profile.dto.OidcProfileRequest;
 import com.nestrr.apps.flock.profile.dto.ProfileDto;
-import com.nestrr.apps.flock.profile.entity.Person;
+import com.nestrr.apps.flock.shared.AuthenticatedTest;
 import io.restassured.http.ContentType;
 import java.util.List;
 import org.junit.jupiter.api.*;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class ProfileControllerTest extends AbstractIntegrationTest {
-  @LocalServerPort private int port;
+class ProfileControllerTest extends AuthenticatedTest {
+
+
 
   @DynamicPropertySource
   static void registerPgProperties(DynamicPropertyRegistry registry) {
@@ -25,23 +25,6 @@ class ProfileControllerTest extends AbstractIntegrationTest {
     registry.add("spring.datasource.username", postgres::getUsername);
     registry.add("spring.datasource.password", postgres::getPassword);
     registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
-  }
-
-  @Test
-  @Order(0)
-  void canCreateProfile() {
-    OidcProfileRequest oidcProfileRequest =
-        OidcProfileRequest.builder().name("Test").email("test@gmail.com").image("image").build();
-    setBearerToken(oidcProfileRequest.getEmail(), "password");
-    given()
-        .port(port)
-        .contentType(ContentType.JSON)
-        .header("Authorization", "Bearer " + getBearerToken())
-        .when()
-        .body(oidcProfileRequest)
-        .post("/profile/me")
-        .then()
-        .statusCode(HttpStatus.NO_CONTENT.value());
   }
 
   @Test
@@ -66,7 +49,7 @@ class ProfileControllerTest extends AbstractIntegrationTest {
 
     ProfileDto profileDto =
         given()
-            .port(port)
+            .port(getPort())
             .contentType(ContentType.JSON)
             .header("Authorization", "Bearer " + getBearerToken())
             .when()
@@ -80,7 +63,7 @@ class ProfileControllerTest extends AbstractIntegrationTest {
     OidcProfileRequest oidcProfileRequest =
         OidcProfileRequest.builder().name("Test").email("test@gmail.com").image("image").build();
     given()
-        .port(port)
+        .port(getPort())
         .contentType(ContentType.JSON)
         .body(oidcProfileRequest)
         .when()
@@ -95,7 +78,7 @@ class ProfileControllerTest extends AbstractIntegrationTest {
         OidcProfileRequest.builder().name("Test").email("test@gmail.com").image("image").build();
     String fakeBearerToken = "randomxyz";
     given()
-        .port(port)
+        .port(getPort())
         .header("Authorization", fakeBearerToken)
         .contentType(ContentType.JSON)
         .body(oidcProfileRequest)
@@ -124,7 +107,7 @@ class ProfileControllerTest extends AbstractIntegrationTest {
 
     setBearerToken(oidcProfileRequest.getEmail(), "password");
     given()
-        .port(port)
+        .port(getPort())
         .contentType(ContentType.JSON)
         .header("Authorization", "Bearer " + getBearerToken())
         .body(oidcProfileRequest)
@@ -133,7 +116,7 @@ class ProfileControllerTest extends AbstractIntegrationTest {
 
     // Assert 204 NO CONTENT status code
     given()
-        .port(port)
+        .port(getPort())
         .contentType(ContentType.JSON)
         .header("Authorization", "Bearer " + getBearerToken())
         //        .body(updateProfileRequest)
@@ -142,7 +125,7 @@ class ProfileControllerTest extends AbstractIntegrationTest {
         .then()
         .statusCode(HttpStatus.NO_CONTENT.value());
 
-    Person person = personRepository.findByEmail(oidcProfileRequest.getEmail()).orElseThrow();
+    //    Person person = personRepository.findByEmail(oidcProfileRequest.getEmail()).orElseThrow();
     //    assertEquals(person.getName(), updateProfileRequest.getName());
     //    assertEquals(person.getImage(), updateProfileRequest.getProfilePicture());
     //    assertEquals(person.getBio(), updateProfileRequest.getBio());

--- a/src/test/java/com/nestrr/apps/flock/profile/ProgramControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/profile/ProgramControllerTest.java
@@ -2,17 +2,15 @@ package com.nestrr.apps.flock.profile;
 
 import static io.restassured.RestAssured.given;
 
-import com.nestrr.apps.flock.profile.dto.OidcProfileRequest;
+import com.nestrr.apps.flock.shared.AuthenticatedTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.*;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class ProgramControllerTest extends AbstractIntegrationTest {
-  @LocalServerPort private int port;
+class ProgramControllerTest extends AuthenticatedTest {
 
   @DynamicPropertySource
   static void registerPgProperties(DynamicPropertyRegistry registry) {
@@ -22,27 +20,10 @@ class ProgramControllerTest extends AbstractIntegrationTest {
     registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
   }
 
-  private final OidcProfileRequest oidcProfileRequest =
-      OidcProfileRequest.builder().name("Test").email("test@gmail.com").image("image").build();
-
-  @BeforeEach
-  void canCreateProfile() {
-    setBearerToken(oidcProfileRequest.getEmail(), "password");
-    given()
-        .port(port)
-        .contentType(ContentType.JSON)
-        .header("Authorization", "Bearer " + getBearerToken())
-        .when()
-        .body(oidcProfileRequest)
-        .post("/profile/me")
-        .then()
-        .statusCode(HttpStatus.NO_CONTENT.value());
-  }
-
   @Test
   void canGetPrograms() {
     given()
-        .port(port)
+        .port(getPort())
         .contentType(ContentType.JSON)
         .header("Authorization", "Bearer " + getBearerToken())
         .when()

--- a/src/test/java/com/nestrr/apps/flock/profile/StandingControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/profile/StandingControllerTest.java
@@ -2,17 +2,15 @@ package com.nestrr.apps.flock.profile;
 
 import static io.restassured.RestAssured.given;
 
-import com.nestrr.apps.flock.profile.dto.OidcProfileRequest;
+import com.nestrr.apps.flock.shared.AuthenticatedTest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.*;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class StandingControllerTest extends AbstractIntegrationTest {
-  @LocalServerPort private int port;
+class StandingControllerTest extends AuthenticatedTest {
 
   @DynamicPropertySource
   static void registerPgProperties(DynamicPropertyRegistry registry) {
@@ -22,27 +20,10 @@ class StandingControllerTest extends AbstractIntegrationTest {
     registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
   }
 
-  private final OidcProfileRequest oidcProfileRequest =
-      OidcProfileRequest.builder().name("Test").email("test@gmail.com").image("image").build();
-
-  @BeforeEach
-  void canCreateProfile() {
-    setBearerToken(oidcProfileRequest.getEmail(), "password");
-    given()
-        .port(port)
-        .contentType(ContentType.JSON)
-        .header("Authorization", "Bearer " + getBearerToken())
-        .when()
-        .body(oidcProfileRequest)
-        .post("/profile/me")
-        .then()
-        .statusCode(HttpStatus.NO_CONTENT.value());
-  }
-
   @Test
   void canGetStandings() {
     given()
-        .port(port)
+        .port(getPort())
         .contentType(ContentType.JSON)
         .header("Authorization", "Bearer " + getBearerToken())
         .when()

--- a/src/test/java/com/nestrr/apps/flock/shared/AbstractIntegrationTest.java
+++ b/src/test/java/com/nestrr/apps/flock/shared/AbstractIntegrationTest.java
@@ -1,0 +1,30 @@
+package com.nestrr.apps.flock.shared;
+
+import static io.restassured.RestAssured.given;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nestrr.apps.flock.profile.repository.PersonRepository;
+import com.nestrr.apps.flock.profile.repository.RoleAssignmentRepository;
+import com.nestrr.apps.flock.profile.repository.RoleRepository;
+import io.restassured.response.Response;
+import java.time.Duration;
+import java.util.Base64;
+import lombok.Getter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.jdbc.JdbcConnectionDetails;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles(profiles = {"test"})
+public interface AbstractIntegrationTest {}

--- a/src/test/java/com/nestrr/apps/flock/shared/AuthenticatedTest.java
+++ b/src/test/java/com/nestrr/apps/flock/shared/AuthenticatedTest.java
@@ -1,33 +1,52 @@
-package com.nestrr.apps.flock.profile;
+package com.nestrr.apps.flock.shared;
 
 import static io.restassured.RestAssured.given;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nestrr.apps.flock.profile.dto.OidcProfileRequest;
 import com.nestrr.apps.flock.profile.repository.PersonRepository;
 import com.nestrr.apps.flock.profile.repository.RoleAssignmentRepository;
 import com.nestrr.apps.flock.profile.repository.RoleRepository;
+import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.time.Duration;
 import java.util.Base64;
 import lombok.Getter;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.jdbc.JdbcConnectionDetails;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.http.HttpStatus;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Testcontainers
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles(profiles = {"test"})
-abstract class AbstractIntegrationTest {
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public abstract class AuthenticatedTest implements AbstractIntegrationTest {
+
+  @Getter @LocalServerPort private int port;
+
+  @Value("${oidc.authorization.url}")
+  private String authorizationUrl;
+
+  @Value("${oidc.token.url}")
+  private String tokenUrl;
+
+  @Value("${oidc.login.url}")
+  private String loginUrl;
+
+  @Getter private String bearerToken;
+
+  @Autowired private PersonRepository personRepository;
+  @Autowired private RoleRepository roleRepository;
+  @Autowired private RoleAssignmentRepository roleAssignmentRepository;
+  @Autowired private ObjectMapper mapper;
+
+  private final OidcProfileRequest oidcProfileRequest =
+      OidcProfileRequest.builder().name("Test").email("test@gmail.com").image("image").build();
 
   @Container
   @ServiceConnection(type = JdbcConnectionDetails.class)
@@ -43,22 +62,6 @@ abstract class AbstractIntegrationTest {
   static void afterAll() {
     postgres.stop();
   }
-
-  @Autowired PersonRepository personRepository;
-  @Autowired RoleRepository userRoleRepository;
-  @Autowired RoleAssignmentRepository roleAssignmentRepository;
-  @Autowired ObjectMapper mapper;
-
-  @Value("${oidc.authorization.url}")
-  private String authorizationUrl;
-
-  @Value("${oidc.token.url}")
-  private String tokenUrl;
-
-  @Value("${oidc.login.url}")
-  private String loginUrl;
-
-  @Getter private String bearerToken;
 
   public String fetchAuthorizationCode(String email, String password) {
     System.out.println("============++++++GETTING AUTH CODE++++++============");
@@ -104,5 +107,19 @@ abstract class AbstractIntegrationTest {
     } catch (JsonProcessingException e) {
       return "";
     }
+  }
+
+  @BeforeEach
+  void canCreateProfile() {
+    setBearerToken(oidcProfileRequest.getEmail(), "password");
+    given()
+        .port(port)
+        .contentType(ContentType.JSON)
+        .header("Authorization", "Bearer " + getBearerToken())
+        .when()
+        .body(oidcProfileRequest)
+        .post("/profile/me")
+        .then()
+        .statusCode(HttpStatus.NO_CONTENT.value());
   }
 }

--- a/src/test/java/com/nestrr/apps/flock/shared/UnauthenticatedTest.java
+++ b/src/test/java/com/nestrr/apps/flock/shared/UnauthenticatedTest.java
@@ -1,0 +1,32 @@
+package com.nestrr.apps.flock.shared;
+
+
+import java.time.Duration;
+import lombok.Getter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.boot.autoconfigure.jdbc.JdbcConnectionDetails;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+public abstract class UnauthenticatedTest implements AbstractIntegrationTest {
+
+  @Getter @LocalServerPort private int port;
+
+  @Container
+  @ServiceConnection(type = JdbcConnectionDetails.class)
+  public static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>("postgres:17").withMinimumRunningDuration(Duration.ofSeconds(5L));
+
+  @BeforeAll
+  static void beforeAll() {
+    postgres.start();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    postgres.stop();
+  }
+}


### PR DESCRIPTION
This PR sets up group creation, complete with emailing invites to users. Per FLOC-69 and spec, creators are saved as group members immediately, and the group is in pending state. (The next parts, including updating group state when at least one user accepts an invite, etc, will be part of future PRs.)

