### PR TITLE
Allow users to get their groups, check in test resources from earlier PR

### DIFF
--- a/src/main/java/com/nestrr/apps/flock/group/controller/GroupController.java
+++ b/src/main/java/com/nestrr/apps/flock/group/controller/GroupController.java
@@ -21,7 +21,7 @@ public class GroupController {
 
   @GetMapping("/me")
   public ResponseEntity<List<GroupDto>> getSelfGroups(Authentication auth) {
-    return ResponseEntity.ok(List.of());
+    return ResponseEntity.ok(groupFacadeService.getSelfGroups(auth));
   }
 
   @PostMapping

--- a/src/main/java/com/nestrr/apps/flock/group/entity/GroupMembership.java
+++ b/src/main/java/com/nestrr/apps/flock/group/entity/GroupMembership.java
@@ -2,14 +2,15 @@ package com.nestrr.apps.flock.group.entity;
 
 import com.nestrr.apps.flock.group.entity.id.GroupMembershipId;
 import jakarta.persistence.*;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Objects;
-
 @Entity
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public final class GroupMembership {

--- a/src/main/java/com/nestrr/apps/flock/group/repository/GroupMembershipRepository.java
+++ b/src/main/java/com/nestrr/apps/flock/group/repository/GroupMembershipRepository.java
@@ -1,10 +1,19 @@
 package com.nestrr.apps.flock.group.repository;
 
 import com.nestrr.apps.flock.group.entity.GroupMembership;
+import com.nestrr.apps.flock.group.entity.GroupView;
 import com.nestrr.apps.flock.group.entity.id.GroupMembershipId;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.ListCrudRepository;
 import org.springframework.data.repository.ListPagingAndSortingRepository;
 
 public interface GroupMembershipRepository
     extends ListPagingAndSortingRepository<GroupMembership, GroupMembershipId>,
-        ListCrudRepository<GroupMembership, GroupMembershipId> {}
+        ListCrudRepository<GroupMembership, GroupMembershipId> {
+  @Query(
+      nativeQuery = true,
+      value =
+          "SELECT gv.* FROM group_membership gm JOIN group_view gv ON gm.group_id=gv.id WHERE gm.person_id=?1")
+  List<GroupView> findGroupsByGroupId(String personId);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeService.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeService.java
@@ -1,8 +1,12 @@
 package com.nestrr.apps.flock.group.service;
 
+import com.nestrr.apps.flock.group.dto.GroupDto;
 import com.nestrr.apps.flock.group.dto.NewGroupRequest;
+import java.util.*;
 import org.springframework.security.core.Authentication;
 
 public interface GroupFacadeService {
   void createGroup(Authentication auth, NewGroupRequest newGroupRequest);
+
+  List<GroupDto> getSelfGroups(Authentication auth);
 }

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupFacadeServiceImpl.java
@@ -2,6 +2,7 @@ package com.nestrr.apps.flock.group.service;
 
 import static com.nestrr.apps.flock.util.AuthenticationUtil.getJwtId;
 
+import com.nestrr.apps.flock.group.dto.GroupDto;
 import com.nestrr.apps.flock.group.dto.NewGroupRequest;
 import com.nestrr.apps.flock.group.entity.Group;
 import java.util.*;
@@ -13,10 +14,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class GroupFacadeServiceImpl implements GroupFacadeService {
   private final GroupService groupService;
   private final GroupInviteService groupInviteService;
+  private final GroupMembershipService groupMembershipService;
 
-  public GroupFacadeServiceImpl(GroupService groupService, GroupInviteService groupInviteService) {
+  public GroupFacadeServiceImpl(
+      GroupService groupService,
+      GroupInviteService groupInviteService,
+      GroupMembershipService groupMembershipService) {
     this.groupService = groupService;
     this.groupInviteService = groupInviteService;
+    this.groupMembershipService = groupMembershipService;
   }
 
   @Override
@@ -26,5 +32,11 @@ public class GroupFacadeServiceImpl implements GroupFacadeService {
     Group group = groupService.createGroup(creatorId, newGroupRequest);
     groupInviteService.createInvites(group, newGroupRequest.members());
     groupMembershipService.addMember(group.getId(), creatorId);
+  }
+
+  @Override
+  public List<GroupDto> getSelfGroups(Authentication auth) {
+    String personId = getJwtId(auth);
+    return groupMembershipService.getGroupsByPersonId(personId);
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupMembershipService.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupMembershipService.java
@@ -1,0 +1,12 @@
+package com.nestrr.apps.flock.group.service;
+
+import com.nestrr.apps.flock.group.dto.GroupDto;
+import java.util.List;
+
+public interface GroupMembershipService {
+  void addMember(String groupId, String personId);
+
+  void removeMember(String groupId, String personId);
+
+  List<GroupDto> getGroupsByPersonId(String personId);
+}

--- a/src/main/java/com/nestrr/apps/flock/group/service/GroupMembershipServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/group/service/GroupMembershipServiceImpl.java
@@ -1,0 +1,42 @@
+package com.nestrr.apps.flock.group.service;
+
+import com.nestrr.apps.flock.group.dto.GroupDto;
+import com.nestrr.apps.flock.group.entity.GroupMembership;
+import com.nestrr.apps.flock.group.entity.id.GroupMembershipId;
+import com.nestrr.apps.flock.group.mapper.GroupMapper;
+import com.nestrr.apps.flock.group.repository.GroupMembershipRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class GroupMembershipServiceImpl implements GroupMembershipService {
+  private final GroupMembershipRepository groupMembershipRepository;
+  private final GroupMapper groupMapper;
+
+  public GroupMembershipServiceImpl(
+      GroupMembershipRepository groupMembershipRepository, GroupMapper groupMapper) {
+    this.groupMembershipRepository = groupMembershipRepository;
+    this.groupMapper = groupMapper;
+  }
+
+  @Override
+  @Transactional
+  public void addMember(String groupId, String personId) {
+    groupMembershipRepository.save(
+        GroupMembership.builder().id(new GroupMembershipId(groupId, personId)).build());
+  }
+
+  @Override
+  @Transactional
+  public void removeMember(String groupId, String personId) {
+    groupMembershipRepository.deleteById(new GroupMembershipId(groupId, personId));
+  }
+
+  @Override
+  public List<GroupDto> getGroupsByPersonId(String personId) {
+    return groupMembershipRepository.findGroupsByGroupId(personId).stream()
+        .map(groupMapper::toGroupDto)
+        .toList();
+  }
+}

--- a/src/test/java/com/nestrr/apps/flock/group/GroupControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/group/GroupControllerTest.java
@@ -2,6 +2,7 @@ package com.nestrr.apps.flock.group;
 
 import static io.restassured.RestAssured.given;
 
+import com.nestrr.apps.flock.group.dto.GroupDto;
 import com.nestrr.apps.flock.group.dto.NewGroupRequest;
 import com.nestrr.apps.flock.group.entity.Group;
 import com.nestrr.apps.flock.group.entity.GroupInvite;
@@ -11,6 +12,7 @@ import com.nestrr.apps.flock.profile.entity.Person;
 import com.nestrr.apps.flock.profile.repository.PersonRepository;
 import com.nestrr.apps.flock.shared.AuthenticatedTest;
 import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
 import java.util.List;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +32,20 @@ class GroupControllerTest extends AuthenticatedTest {
     registry.add("spring.datasource.username", postgres::getUsername);
     registry.add("spring.datasource.password", postgres::getPassword);
     registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+  }
+
+  @Test
+  void canGetGroups() {
+    JsonPath jsonPath =
+        given()
+            .port(getPort())
+            .contentType(ContentType.JSON)
+            .header("Authorization", "Bearer " + getBearerToken())
+            .when()
+            .get("/group/me")
+            .jsonPath();
+    List<GroupDto> groups = jsonPath.getList("$");
+    Assertions.assertEquals(0, groups.size());
   }
 
   @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,15 @@
+spring:
+  mail:
+    host: smtp-mail.outlook.com
+    port: 587
+    username: fake@outlook.com
+    password: fake
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            required: true
 oidc:
   login:
     url: https://nestrr.wiremockapi.cloud/login

--- a/src/test/resources/email-templates/group-invite/template.html
+++ b/src/test/resources/email-templates/group-invite/template.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <title th:text="${pageTitle}">Group Invite Template Title</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+</head>
+
+<body>
+<h1>Hey again! 👋🐦</h1>
+
+<p>You've got a new group invite! <span style="font-weight:bold;" th:text="${adminName}"></span> is inviting you to join
+    <span style="font-weight:bold;" th:text="${groupName}"></span>.</p>
+<p>
+    Here's a little more about the group:
+</p>
+<span style="font-weight:italic;" th:text="${groupDescription}"></span>
+<br/>
+<p>What do you think? <a href="${inviteUrl}" target="_blank">Click here to accept or reject the invite.</a> <b>After a
+    week, your
+    invite will expire, so be sure to accept the invite before then if you're interested!</b></p>
+
+<br/>
+<br/>
+<p>Cheers,</p>
+<p>The Nestrr team</p>
+<!-- ... -->
+</body>
+
+</html>


### PR DESCRIPTION
Per FLOC-71 and spec, this PR creates an endpoint for users to retrieve the groups they either created or are an active member of. (It does not include groups they were invited to, regardless of invite pending/rejection/expired status). The resources directory in `test` was  also changed by the previous PR, but the files were not checked in. This PR resolves that.
