### PR TITLE
Fix failure in messaging service, improve logging

### DIFF
--- a/src/main/java/com/nestrr/apps/flock/config/DataLoader.java
+++ b/src/main/java/com/nestrr/apps/flock/config/DataLoader.java
@@ -9,6 +9,8 @@ import com.nestrr.apps.flock.standing.entity.Standing;
 import com.nestrr.apps.flock.standing.repository.StandingRepository;
 import java.time.LocalTime;
 import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -29,6 +31,7 @@ public class DataLoader implements ApplicationRunner {
   private final CampusChoiceRankRepository campusChoiceRankRepository;
   private final CampusRepository campusRepository;
   private final TimeslotRepository timeslotRepository;
+  private final Logger log;
 
   public DataLoader(
       PersonRepository personRepository,
@@ -49,6 +52,7 @@ public class DataLoader implements ApplicationRunner {
     this.campusChoiceRankRepository = campusChoiceRankRepository;
     this.campusRepository = campusRepository;
     this.timeslotRepository = timeslotRepository;
+    this.log = LoggerFactory.getLogger(DataLoader.class);
   }
 
   public void createTimeslots(String personId) {
@@ -125,13 +129,13 @@ public class DataLoader implements ApplicationRunner {
   }
 
   public void run(ApplicationArguments args) {
-    System.out.println("DataLoader: Filling in details.");
+    log.debug("DataLoader: Filling in details.");
     List<Standing> standings = standingRepository.findAll();
     List<DegreeView> degrees = degreeViewRepository.findAll(Sort.unsorted());
     List<Campus> campuses = campusRepository.findAll();
     List<Role> roles = roleRepository.findAll(Sort.unsorted());
     List<Person> persons = personRepository.findAll();
     persons.parallelStream().forEach(p -> fillDetails(p, standings, degrees, campuses, roles));
-    System.out.println("DataLoader: Filling details complete.");
+    log.debug("DataLoader: Filling details complete.");
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/config/JwtAuthenticationConverter.java
+++ b/src/main/java/com/nestrr/apps/flock/config/JwtAuthenticationConverter.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -16,11 +18,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JwtAuthenticationConverter implements Converter<Jwt, JwtAuthenticationToken> {
-
+  private final Logger log;
   private final RoleAssignmentRepository roleAssignmentRepository;
 
   public JwtAuthenticationConverter(RoleAssignmentRepository roleAssignmentRepository) {
     this.roleAssignmentRepository = roleAssignmentRepository;
+    log = LoggerFactory.getLogger(JwtAuthenticationConverter.class);
   }
 
   @Override
@@ -41,7 +44,7 @@ public class JwtAuthenticationConverter implements Converter<Jwt, JwtAuthenticat
               .map(r -> new SimpleGrantedAuthority("ROLE_" + r))
               .collect(Collectors.toList());
     }
-    System.out.println("AUTHORITIES ARE SET TO " + authorities);
+    log.debug("Authorities for {}: {}", subId, authorities);
     return new JwtAuthenticationToken(source, authorities);
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/group/controller/GroupController.java
+++ b/src/main/java/com/nestrr/apps/flock/group/controller/GroupController.java
@@ -33,22 +33,18 @@ public class GroupController {
     return ResponseEntity.ok().build();
   }
 
-  @PatchMapping("/{id}")
-  @PreAuthorize("isGroupOwner(#groupId, authentication.name)")
+  @PatchMapping("/{groupId}")
+  @PreAuthorize("@groupFacadeServiceImpl.isGroupOwner(#groupId, authentication.name)")
   public ResponseEntity<String> updateGroup(
       @PathVariable String groupId, @Valid @RequestBody UpdateGroupRequest updateGroupRequest) {
     groupFacadeService.updateGroup(groupId, updateGroupRequest);
     return ResponseEntity.noContent().build();
   }
 
-  @DeleteMapping("/{id}")
-  @PreAuthorize("isGroupOwner(#groupId, authentication.name)")
+  @DeleteMapping("/{groupId}")
+  @PreAuthorize("@groupFacadeServiceImpl.isGroupOwner(#groupId, authentication.name)")
   public ResponseEntity<String> deleteGroup(@PathVariable String groupId) {
     groupFacadeService.deleteGroup(groupId);
     return ResponseEntity.noContent().build();
-  }
-
-  public boolean isGroupOwner(String groupId, String personId) {
-    return groupFacadeService.isGroupOwner(groupId, personId);
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/messaging/entity/Email.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/entity/Email.java
@@ -2,11 +2,7 @@ package com.nestrr.apps.flock.messaging.entity;
 
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
-import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Data
@@ -19,9 +15,10 @@ public final class Email {
   private String id;
 
   @Version private Integer version;
-  private List<String> recipients;
+  private String sender;
+  private String recipient;
   private final LocalDateTime timestamp = LocalDateTime.now();
-  private String subject;
+  @NonNull private String subject;
   @Builder.Default private String htmlBody = "";
   @Builder.Default private String textBody = "";
   private boolean success;

--- a/src/main/java/com/nestrr/apps/flock/messaging/service/EmailSenderImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/service/EmailSenderImpl.java
@@ -3,6 +3,7 @@ package com.nestrr.apps.flock.messaging.service;
 import com.nestrr.apps.flock.messaging.entity.Email;
 import com.nestrr.apps.flock.messaging.repository.EmailRepository;
 import jakarta.mail.internet.MimeMessage;
+import java.util.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -31,7 +32,7 @@ public class EmailSenderImpl implements EmailSender {
           new MimeMessageHelper(message, MimeMessageHelper.MULTIPART_MODE_MIXED, "UTF-8");
 
       messageHelper.setFrom(systemEmailAddress);
-      messageHelper.setTo(email.getRecipients().toArray(new String[] {}));
+      messageHelper.setTo(email.getRecipient());
       messageHelper.setSubject(email.getSubject());
       messageHelper.setText(email.getTextBody(), email.getHtmlBody());
       this.mailSender.send(message);
@@ -39,7 +40,9 @@ public class EmailSenderImpl implements EmailSender {
       email.setSuccess(false);
       emailRepository.save(email);
       throw new MailSendException(
-          String.format("System email could not be sent to %s.", email.getRecipients().toString()));
+          String.format(
+              "System email could not be sent to %s. \r\n See: %s",
+              email.getRecipient(), e.getMessage()));
     }
     email.setSuccess(true);
     emailRepository.save(email);

--- a/src/main/java/com/nestrr/apps/flock/messaging/service/MessagingServiceImpl.java
+++ b/src/main/java/com/nestrr/apps/flock/messaging/service/MessagingServiceImpl.java
@@ -70,8 +70,10 @@ public class MessagingServiceImpl implements MessagingService {
                                 new NullPointerException(
                                     String.format("Person with ID %s does not have an email", id))))
             .toList();
-    Email email = createGroupDeletionEmail(context, memberEmails);
-    emailService.sendSystemEmail(email);
+    memberEmails.forEach(
+        email -> {
+          emailService.sendSystemEmail(createGroupDeletionEmail(context, email));
+        });
   }
 
   public Email createInviteEmail(
@@ -89,11 +91,7 @@ public class MessagingServiceImpl implements MessagingService {
         String.format("%s/invite/%s?id=%s", frontend, context.group().getId(), recipientId));
 
     String content = emailTemplateEngine.process("group-invite/template.html", ctx);
-    return Email.builder()
-        .subject(subject)
-        .htmlBody(content)
-        .recipients(List.of(recipientEmail))
-        .build();
+    return Email.builder().subject(subject).htmlBody(content).recipient(recipientEmail).build();
   }
 
   public Email createAdminRemovalEmail(AdminChangeContext context, String recipientEmail) {
@@ -107,11 +105,7 @@ public class MessagingServiceImpl implements MessagingService {
     ctx.setVariable("newAdminId", context.newAdmin().getId());
 
     String content = emailTemplateEngine.process("group-admin-removal/template.html", ctx);
-    return Email.builder()
-        .subject(subject)
-        .htmlBody(content)
-        .recipients(List.of(recipientEmail))
-        .build();
+    return Email.builder().subject(subject).htmlBody(content).recipient(recipientEmail).build();
   }
 
   public Email createAdminAssignmentEmail(AdminChangeContext context, String recipientEmail) {
@@ -125,14 +119,10 @@ public class MessagingServiceImpl implements MessagingService {
     ctx.setVariable("oldAdminName", context.oldAdmin().getName());
 
     String content = emailTemplateEngine.process("group-admin-assignment/template.html", ctx);
-    return Email.builder()
-        .subject(subject)
-        .htmlBody(content)
-        .recipients(List.of(recipientEmail))
-        .build();
+    return Email.builder().subject(subject).htmlBody(content).recipient(recipientEmail).build();
   }
 
-  public Email createGroupDeletionEmail(GroupDeleteContext context, List<String> recipientEmails) {
+  public Email createGroupDeletionEmail(GroupDeleteContext context, String recipientEmail) {
     String subject = String.format("Important: %s has shut down.", context.group().getName());
     Context ctx = new Context(Locale.US);
     ctx.setVariable("pageTitle", subject);
@@ -140,6 +130,6 @@ public class MessagingServiceImpl implements MessagingService {
     ctx.setVariable("mainUrl", frontend);
 
     String content = emailTemplateEngine.process("group-deletion/template.html", ctx);
-    return Email.builder().subject(subject).htmlBody(content).recipients(recipientEmails).build();
+    return Email.builder().subject(subject).htmlBody(content).recipient(recipientEmail).build();
   }
 }

--- a/src/main/java/com/nestrr/apps/flock/profile/entity/converter/CampusDtoAttributeConverter.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/entity/converter/CampusDtoAttributeConverter.java
@@ -6,16 +6,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nestrr.apps.flock.profile.dto.CampusDto;
 import jakarta.persistence.AttributeConverter;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CampusDtoAttributeConverter implements AttributeConverter<List<CampusDto>, String> {
   private final ObjectMapper objectMapper = new ObjectMapper();
+  private final Logger log = LoggerFactory.getLogger(CampusDtoAttributeConverter.class);
 
   @Override
   public String convertToDatabaseColumn(List<CampusDto> campusDtos) {
     try {
       return objectMapper.writeValueAsString(campusDtos);
     } catch (JsonProcessingException jpe) {
-      System.out.println("Cannot convert CampusDto list into JSON");
+      log.error("Cannot convert CampusDto list into JSON");
       return null;
     }
   }
@@ -26,7 +29,7 @@ public class CampusDtoAttributeConverter implements AttributeConverter<List<Camp
     try {
       return objectMapper.readValue(value, new TypeReference<List<CampusDto>>() {});
     } catch (JsonProcessingException e) {
-      System.out.println("Cannot convert JSON into CampusDto list");
+      log.error("Cannot convert JSON into CampusDto list");
       return null;
     }
   }

--- a/src/main/java/com/nestrr/apps/flock/profile/entity/converter/DegreeDtoAttributeConverter.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/entity/converter/DegreeDtoAttributeConverter.java
@@ -6,10 +6,13 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.nestrr.apps.flock.profile.dto.DegreeDto;
 import com.nestrr.apps.flock.profile.mapper.DegreeViewMapper;
 import jakarta.persistence.AttributeConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 public class DegreeDtoAttributeConverter implements AttributeConverter<DegreeDto, String> {
+  private final Logger log;
   // not using default mapper to avoid changing its naming settings
   private final ObjectMapper objectMapper =
       new ObjectMapper().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
@@ -18,6 +21,7 @@ public class DegreeDtoAttributeConverter implements AttributeConverter<DegreeDto
   public DegreeDtoAttributeConverter(DegreeViewMapper degreeViewMapper) {
     super();
     this.degreeViewMapper = degreeViewMapper;
+    log = LoggerFactory.getLogger(DegreeDtoAttributeConverter.class);
   }
 
   @Override
@@ -25,7 +29,7 @@ public class DegreeDtoAttributeConverter implements AttributeConverter<DegreeDto
     try {
       return objectMapper.writeValueAsString(degreeViewMapper.viewFromDegreeDto(degreeDto));
     } catch (JsonProcessingException jpe) {
-      System.out.println("Cannot convert DegreeDto into JSON");
+      log.error("Cannot convert DegreeDto into JSON");
       return null;
     }
   }
@@ -36,7 +40,7 @@ public class DegreeDtoAttributeConverter implements AttributeConverter<DegreeDto
     try {
       return objectMapper.readValue(value, DegreeDto.class);
     } catch (JsonProcessingException e) {
-      System.out.println("Cannot convert JSON into DegreeDto");
+      log.error("Cannot convert JSON into DegreeDto");
       return null;
     }
   }

--- a/src/main/java/com/nestrr/apps/flock/profile/entity/converter/TimeslotDtoAttributeConverter.java
+++ b/src/main/java/com/nestrr/apps/flock/profile/entity/converter/TimeslotDtoAttributeConverter.java
@@ -10,6 +10,8 @@ import com.nestrr.apps.flock.profile.entity.TimeslotView;
 import com.nestrr.apps.flock.profile.mapper.TimeslotMapper;
 import jakarta.persistence.AttributeConverter;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,10 +23,12 @@ public class TimeslotDtoAttributeConverter
           .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
           .registerModule(new JavaTimeModule());
   private final TimeslotMapper timeslotMapper;
+  private final Logger log;
 
   public TimeslotDtoAttributeConverter(TimeslotMapper timeslotMapper) {
     super();
     this.timeslotMapper = timeslotMapper;
+    this.log = LoggerFactory.getLogger(TimeslotDtoAttributeConverter.class);
   }
 
   @Override
@@ -33,7 +37,7 @@ public class TimeslotDtoAttributeConverter
       return objectMapper.writeValueAsString(
           timeslotDtos.stream().map(timeslotMapper::viewFromTimeslotDto).toList());
     } catch (JsonProcessingException jpe) {
-      System.out.println("Cannot convert TimeslotDto list into JSON");
+      log.error("Cannot convert TimeslotDto list into JSON");
       return null;
     }
   }
@@ -46,7 +50,7 @@ public class TimeslotDtoAttributeConverter
           objectMapper.readValue(value, new TypeReference<List<TimeslotView>>() {});
       return timeslotViewObjects.stream().map(timeslotMapper::toTimeslotDto).toList();
     } catch (JsonProcessingException e) {
-      System.out.println("Cannot convert JSON into TimeslotDto list");
+      log.error("Cannot convert JSON into TimeslotDto list");
       return null;
     }
   }

--- a/src/main/resources/db/changelog/changelog-1.0/changelog-1.0.5.yaml
+++ b/src/main/resources/db/changelog/changelog-1.0/changelog-1.0.5.yaml
@@ -1,0 +1,56 @@
+databaseChangeLog:
+  - changeSet:
+      # Create the email table
+      id: 202503101250
+      author: maryamkhan
+      runOnChange: true
+      changes:
+        - createTable:
+            tableName: email
+            columns:
+              - column:
+                  name: id
+                  type: text
+                  defaultValueComputed: gen_random_uuid()::text
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_email
+                    nullable: false
+              - column:
+                  name: version
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: sender
+                  type: text
+              - column:
+                  name: recipient
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: timestamp
+                  type: datetime
+                  constraints:
+                    nullable: false
+              - column:
+                  name: subject
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: html_body
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: text_body
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: success
+                  type: boolean
+                  constraints:
+                    nullable: false

--- a/src/test/java/com/nestrr/apps/flock/group/GroupControllerTest.java
+++ b/src/test/java/com/nestrr/apps/flock/group/GroupControllerTest.java
@@ -80,4 +80,36 @@ class GroupControllerTest extends AuthenticatedTest {
         groupInviteRepository.findByIdGroupId(groupsCreated.getFirst().getId());
     Assertions.assertEquals(members.size(), groupInvitesCreated.size());
   }
+
+  @Test
+  @Disabled(value = "Need to set up alternate sender email config for tests to use.")
+  void canDeleteGroup() {
+    NewGroupRequest request =
+        new NewGroupRequest(
+            List.of(), "Test group for group deletion", "Test description", "Test image");
+    given()
+        .port(getPort())
+        .contentType(ContentType.JSON)
+        .header("Authorization", "Bearer " + getBearerToken())
+        .when()
+        .body(request)
+        .post("/group")
+        .then()
+        .statusCode(HttpStatus.OK.value());
+
+    Group group =
+        groupRepository.findByAdminId(getUserId()).stream()
+            .filter(g -> g.getName().equals(request.name()))
+            .toList()
+            .getFirst();
+    given()
+        .port(getPort())
+        .header("Authorization", "Bearer " + getBearerToken())
+        .when()
+        .body(request)
+        .delete(String.format("/group/%s", group.getId()))
+        .then()
+        .statusCode(HttpStatus.NO_CONTENT.value());
+    Assertions.assertTrue(groupRepository.findById(group.getId()).isEmpty());
+  }
 }

--- a/src/test/java/com/nestrr/apps/flock/shared/AuthenticatedTest.java
+++ b/src/test/java/com/nestrr/apps/flock/shared/AuthenticatedTest.java
@@ -15,6 +15,8 @@ import java.time.Duration;
 import java.util.Base64;
 import lombok.Getter;
 import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.jdbc.JdbcConnectionDetails;
@@ -44,7 +46,7 @@ public abstract class AuthenticatedTest implements AbstractIntegrationTest {
   @Autowired private RoleRepository roleRepository;
   @Autowired private RoleAssignmentRepository roleAssignmentRepository;
   @Autowired private ObjectMapper mapper;
-
+  private final Logger log = LoggerFactory.getLogger(AuthenticatedTest.class);
   private final OidcProfileRequest oidcProfileRequest =
       OidcProfileRequest.builder().name("Test").email("test@gmail.com").image("image").build();
 
@@ -88,8 +90,7 @@ public abstract class AuthenticatedTest implements AbstractIntegrationTest {
   }
 
   public void setBearerToken(String email, String password) {
-    System.out.println(
-        "============++++++SIMULATING OAUTH2.0, AUTHORIZATION CODE FLOW++++++============");
+    log.debug("============++++++SIMULATING OAUTH2.0, AUTHORIZATION CODE FLOW++++++============");
     this.bearerToken = fetchBearerToken(fetchAuthorizationCode(email, password));
   }
 


### PR DESCRIPTION
After adding tests for FLOC-73, the messaging service was failing due to some logic errors and missing schema setup. This PR fixes that and also uses the slf4j logger in place of print statements, which is much more robust.
